### PR TITLE
Join Primitive Wrapper and Pipeline

### DIFF
--- a/primitive/compute/description/preprocessing.go
+++ b/primitive/compute/description/preprocessing.go
@@ -378,20 +378,16 @@ func CreateGoatReversePipeline(name string, description string, lonSource string
 	return pipeline, nil
 }
 
-// CreateJoinPipeline creates a pipeline that joins two input datasets on a caller supplied column.
-func CreateJoinPipeline(name string, description string, joinCol string) (*pipeline.PipelineDescription, error) {
-	// insantiate the pipeline - this merges two intput streams via a single join call
+// CreateJoinPipeline creates a pipeline that joins two input datasets using a caller supplied column.
+func CreateJoinPipeline(name string, description string, leftJoinCol string, rightJoinCol string) (*pipeline.PipelineDescription, error) {
+	// compute column indices
+
+	// instantiate the pipeline - this merges two intput streams via a single join call
 	step0_0 := NewPipelineNode(NewDenormalizeStep())
-	step0_1 := NewPipelineNode(NewDatasetToDataframeStep())
-	step0_0.Add(step0_1)
-
 	step1_0 := NewPipelineNode(NewDenormalizeStep())
-	step1_1 := NewPipelineNode(NewDatasetToDataframeStep())
-	step1_0.Add(step1_1)
-
-	step2 := NewPipelineNode(NewJoinStep(joinCol))
-	step0_1.Add(step2)
-	step1_1.Add(step2)
+	step2 := NewPipelineNode(NewJoinStep(leftJoinCol, rightJoinCol))
+	step0_0.Add(step2)
+	step1_0.Add(step2)
 
 	pipeline, err := NewPipelineBuilder(name, description, step0_0, step1_0).Compile()
 	if err != nil {

--- a/primitive/compute/description/preprocessing_test.go
+++ b/primitive/compute/description/preprocessing_test.go
@@ -220,7 +220,7 @@ func TestCreateGoatReversePipeline(t *testing.T) {
 }
 
 func TestCreateJoinPipeline(t *testing.T) {
-	pipeline, err := CreateJoinPipeline("join_test", "test join pipeline", "player_name")
+	pipeline, err := CreateJoinPipeline("join_test", "test join pipeline", "player_name", "player_name")
 	assert.NoError(t, err)
 
 	data, err := proto.Marshal(pipeline)

--- a/primitive/compute/description/primitive_steps.go
+++ b/primitive/compute/description/primitive_steps.go
@@ -353,17 +353,19 @@ func NewGoatReverseStep(lonCol string, latCol string) *StepData {
 	)
 }
 
-func NewJoinStep(joinCol string) *StepData {
+// NewJoinStep creates a step that will attempt to join two datasets a key column
+// from each.  This is currently a placeholder for testing/debugging only.
+func NewJoinStep(leftCol string, rightCol string) *StepData {
 	return NewStepDataWithAll(
 		&pipeline.Primitive{
-			Id:         "placeholder",
+			Id:         "6c3188bf-322d-4f9b-bb91-68151bf1f17f",
 			Version:    "0.1.0",
-			Name:       "Join",
-			PythonPath: "d3m.primitives.distil.join",
+			Name:       "Fuzzy Join Placeholder",
+			PythonPath: "d3m.primitives.distil.FuzzyJoin",
 			Digest:     "",
 		},
 		[]string{"produce"},
-		map[string]interface{}{"join_col": joinCol},
+		map[string]interface{}{"left_col": leftCol, "right_col": rightCol},
 		[]string{"left", "right"},
 	)
 }


### PR DESCRIPTION
Adds a wrapper for the placeholder join primitive and a basic pipeline to join two input datasets together.