### PR TITLE
Migrate to dataset_map + dataframe primitives

### DIFF
--- a/primitive/compute/description/builder.go
+++ b/primitive/compute/description/builder.go
@@ -372,7 +372,7 @@ func extractCompiledPrimitives(compileResults []*PipelineDescriptionSteps) []*pi
 			// Update the primitive hyperparam value to point to the child primitive
 			step.Step.GetPrimitive().GetHyperparams()[hyperparamName].GetPrimitive().Data = int32(nextIndex + len(compileResults))
 
-			nextIndex = index + 1
+			nextIndex = nextIndex + 1
 		}
 		return nextIndex
 	}

--- a/primitive/compute/description/builder.go
+++ b/primitive/compute/description/builder.go
@@ -126,14 +126,18 @@ func (p *PipelineBuilder) CompileWithOptions(clampMissingInputs bool) (*pipeline
 		return nil, errors.New("compile failed: pipeline requires at least 1 step")
 	}
 
-	pipelineNodes := []*PipelineNode{}
-	idToIndexMap := map[uint64]int{}
-	traversalQueue := []*PipelineNode{}
-
-	// ensure that there aren't any cycles in the graph
 	if checkCycles(p.sources) {
 		return nil, errors.Errorf("compile error: detected cycle in graph")
 	}
+
+	// First step - compute the number of primitives that are used as hyperparameter arguments.
+	// These need to come *before* the member primitives to keep the D3M runtime happy, so we'll leave
+	// space for them at the start of the final primitive array.
+	indexOffset := countHyperparameterPrimitives(p.sources, 0)
+
+	pipelineNodes := []*PipelineNode{}
+	idToIndexMap := map[uint64]int{}
+	traversalQueue := []*PipelineNode{}
 
 	// start processing from the roots
 	refCount := 0
@@ -161,7 +165,7 @@ func (p *PipelineBuilder) CompileWithOptions(clampMissingInputs bool) (*pipeline
 		node := traversalQueue[0]
 		traversalQueue = traversalQueue[1:]
 		var err error
-		pipelineNodes, err = p.processNode(node, pipelineNodes, idToIndexMap, clampMissingInputs)
+		pipelineNodes, err = p.processNode(node, pipelineNodes, idToIndexMap, indexOffset, clampMissingInputs)
 		if err != nil {
 			return nil, err
 		}
@@ -243,7 +247,9 @@ func validate(node *PipelineNode) error {
 	return nil
 }
 
-func (p *PipelineBuilder) processNode(node *PipelineNode, pipelineNodes []*PipelineNode, idToIndexMap map[uint64]int, clampMissingInputs bool) ([]*PipelineNode, error) {
+func (p *PipelineBuilder) processNode(node *PipelineNode, pipelineNodes []*PipelineNode,
+	idToIndexMap map[uint64]int, indexOffset int, clampMissingInputs bool) ([]*PipelineNode, error) {
+
 	// don't re-process
 	if node.visited {
 		return pipelineNodes, nil
@@ -299,7 +305,7 @@ func (p *PipelineBuilder) processNode(node *PipelineNode, pipelineNodes []*Pipel
 
 	// add to the node list
 	pipelineNodes = append(pipelineNodes, node)
-	idToIndexMap[node.nodeID] = len(pipelineNodes) - 1
+	idToIndexMap[node.nodeID] = (len(pipelineNodes) - 1) + indexOffset
 
 	// Mark as visited so we don't reprocess
 	node.visited = true
@@ -356,7 +362,7 @@ func extractCompiledPrimitives(compileResults []*PipelineDescriptionSteps) []*pi
 	index := 0
 
 	// Recursively traverses a primitive's hyperparams that are themselves
-	var traverseAndUpdate func(step *PipelineDescriptionSteps, index int) int
+	var traverseAndUpdate func(*PipelineDescriptionSteps, int) int
 	traverseAndUpdate = func(step *PipelineDescriptionSteps, index int) int {
 		nextIndex := index
 		// need to use sorted keys so args are consistently ordered for debug/testing - go intentionally randomizes
@@ -370,7 +376,7 @@ func extractCompiledPrimitives(compileResults []*PipelineDescriptionSteps) []*pi
 			nextIndex = traverseAndUpdate(nestedStep, nextIndex)
 
 			// Update the primitive hyperparam value to point to the child primitive
-			step.Step.GetPrimitive().GetHyperparams()[hyperparamName].GetPrimitive().Data = int32(nextIndex + len(compileResults))
+			step.Step.GetPrimitive().GetHyperparams()[hyperparamName].GetPrimitive().Data = int32(nextIndex)
 
 			nextIndex = nextIndex + 1
 		}
@@ -380,5 +386,26 @@ func extractCompiledPrimitives(compileResults []*PipelineDescriptionSteps) []*pi
 		pipelineDescriptionSteps = append(pipelineDescriptionSteps, step.Step)
 		index = traverseAndUpdate(step, index)
 	}
-	return append(pipelineDescriptionSteps, nestedPipelineDescriptionSteps...)
+	return append(nestedPipelineDescriptionSteps, pipelineDescriptionSteps...)
+}
+
+// Counts the number of hyperparameters in the pipeline that are themselves primitives.
+func countHyperparameterPrimitives(nodes []*PipelineNode, count int) int {
+	for _, node := range nodes {
+		// count the number of hyperparam primitives for this node and add to our total
+		count = count + countChildPrimitives(node.step, 0)
+		// process this nodes children
+		count = countHyperparameterPrimitives(node.children, count)
+	}
+	return count
+}
+
+func countChildPrimitives(step Step, currCount int) int {
+	for _, value := range step.GetHyperparameters() {
+		childStepData, ok := value.(Step)
+		if ok {
+			currCount = countChildPrimitives(childStepData, currCount+1)
+		}
+	}
+	return currCount
 }

--- a/primitive/compute/description/builder_test.go
+++ b/primitive/compute/description/builder_test.go
@@ -264,18 +264,18 @@ func TestCompoundPipeline(t *testing.T) {
 
 	steps := desc.GetSteps()
 	for i, step := range steps {
-		t.Logf("Step %d: %s", i, step.GetPrimitive().GetPrimitive().GetName())
+		t.Logf("Step %d: %s Inputs: %+v", i, step.GetPrimitive().GetPrimitive().GetName(), step.GetPrimitive().GetArguments()["inputs"])
 	}
 	assert.Equal(t, 7, len(steps))
 
-	primitiveIdx := steps[1].GetPrimitive().GetHyperparams()["primitiveArg-0"].GetPrimitive().GetData()
+	primitiveIdx := steps[5].GetPrimitive().GetHyperparams()["primitiveArg-0"].GetPrimitive().GetData()
+	assert.Equal(t, int32(0), primitiveIdx)
+	primitiveIdx = steps[5].GetPrimitive().GetHyperparams()["primitiveArg-1"].GetPrimitive().GetData()
+	assert.Equal(t, int32(1), primitiveIdx)
+	primitiveIdx = steps[6].GetPrimitive().GetHyperparams()["primitiveArg-0"].GetPrimitive().GetData()
+	assert.Equal(t, int32(2), primitiveIdx)
+	primitiveIdx = steps[6].GetPrimitive().GetHyperparams()["primitiveArg-1"].GetPrimitive().GetData()
 	assert.Equal(t, int32(3), primitiveIdx)
-	primitiveIdx = steps[1].GetPrimitive().GetHyperparams()["primitiveArg-1"].GetPrimitive().GetData()
-	assert.Equal(t, int32(4), primitiveIdx)
-	primitiveIdx = steps[2].GetPrimitive().GetHyperparams()["primitiveArg-0"].GetPrimitive().GetData()
-	assert.Equal(t, int32(5), primitiveIdx)
-	primitiveIdx = steps[2].GetPrimitive().GetHyperparams()["primitiveArg-1"].GetPrimitive().GetData()
-	assert.Equal(t, int32(6), primitiveIdx)
 }
 
 func TestExtraOutputCompile(t *testing.T) {

--- a/primitive/compute/description/builder_test.go
+++ b/primitive/compute/description/builder_test.go
@@ -253,21 +253,26 @@ func TestMergePipeline(t *testing.T) {
 func TestCompoundPipeline(t *testing.T) {
 	step0 := NewPipelineNode(createTestStep(0))
 	step1 := NewPipelineNode(createTestStepWithNestedPrimitives(1, 2))
+	step2 := NewPipelineNode(createTestStepWithNestedPrimitives(2, 2))
 
 	step0.Add(step1)
+	step1.Add(step2)
 
-	desc, err := NewPipelineBuilder("test", "test pipeline", step0, step1).Compile()
+	desc, err := NewPipelineBuilder("test", "test pipeline", step0).Compile()
 	assert.NotNil(t, desc)
 	assert.NoError(t, err)
 
 	steps := desc.GetSteps()
 	assert.Equal(t, 4, len(steps))
 
-	topStep := steps[1]
-	primitiveIdx := topStep.GetPrimitive().GetHyperparams()["primitiveArg-0"].GetPrimitive().GetData()
-	assert.Equal(t, int32(2), primitiveIdx)
-	primitiveIdx = topStep.GetPrimitive().GetHyperparams()["primitiveArg-1"].GetPrimitive().GetData()
+	primitiveIdx := steps[1].GetPrimitive().GetHyperparams()["primitiveArg-0"].GetPrimitive().GetData()
 	assert.Equal(t, int32(3), primitiveIdx)
+	primitiveIdx = steps[1].GetPrimitive().GetHyperparams()["primitiveArg-1"].GetPrimitive().GetData()
+	assert.Equal(t, int32(4), primitiveIdx)
+	primitiveIdx = steps[2].GetPrimitive().GetHyperparams()["primitiveArg-0"].GetPrimitive().GetData()
+	assert.Equal(t, int32(5), primitiveIdx)
+	primitiveIdx = steps[2].GetPrimitive().GetHyperparams()["primitiveArg-1"].GetPrimitive().GetData()
+	assert.Equal(t, int32(6), primitiveIdx)
 }
 
 func TestExtraOutputCompile(t *testing.T) {

--- a/primitive/compute/description/builder_test.go
+++ b/primitive/compute/description/builder_test.go
@@ -263,7 +263,10 @@ func TestCompoundPipeline(t *testing.T) {
 	assert.NoError(t, err)
 
 	steps := desc.GetSteps()
-	assert.Equal(t, 4, len(steps))
+	for i, step := range steps {
+		t.Logf("Step %d: %s", i, step.GetPrimitive().GetPrimitive().GetName())
+	}
+	assert.Equal(t, 7, len(steps))
 
 	primitiveIdx := steps[1].GetPrimitive().GetHyperparams()["primitiveArg-0"].GetPrimitive().GetData()
 	assert.Equal(t, int32(3), primitiveIdx)

--- a/primitive/compute/description/preprocessing.go
+++ b/primitive/compute/description/preprocessing.go
@@ -54,10 +54,7 @@ func CreateUserDatasetPipeline(name string, description string, allFeatures []*m
 	}
 
 	// create the feature selection primitive
-	removeFeatures, err := createRemoveFeatures(allFeatures, selectedSet)
-	if err != nil {
-		return nil, err
-	}
+	removeFeatures := createRemoveFeatures(allFeatures, selectedSet)
 
 	// add filter primitives
 	filterData := createFilterData(filters, columnIndices)
@@ -101,7 +98,7 @@ func CreateUserDatasetPipeline(name string, description string, allFeatures []*m
 	return pip, nil
 }
 
-func createRemoveFeatures(allFeatures []*model.Variable, selectedSet map[string]bool) (*StepData, error) {
+func createRemoveFeatures(allFeatures []*model.Variable, selectedSet map[string]bool) *StepData {
 	// create a list of features to remove
 	removeFeatures := []int{}
 	for _, v := range allFeatures {
@@ -111,15 +108,12 @@ func createRemoveFeatures(allFeatures []*model.Variable, selectedSet map[string]
 	}
 
 	if len(removeFeatures) == 0 {
-		return nil, nil
+		return nil
 	}
 
 	// instantiate the feature remove primitive
-	featureSelect, err := NewRemoveColumnsStep("", removeFeatures)
-	if err != nil {
-		return nil, err
-	}
-	return featureSelect, nil
+	featureSelect := NewRemoveColumnsStep("", removeFeatures)
+	return featureSelect
 }
 
 type update struct {
@@ -176,27 +170,28 @@ func createUpdateSemanticTypes(allFeatures []*model.Variable, selectedSet map[st
 	semanticTypeUpdates := []*StepData{}
 	for _, k := range keys {
 		v := updateMap[k]
+
 		var addKey string
 		if len(v.addIndices) > 0 {
 			addKey = k
+			add := &ColumnUpdate{
+				SemanticTypes: []string{addKey},
+				Indices:       v.addIndices,
+			}
+			addUpdate := NewAddSemanticTypeStep("", add)
+			semanticTypeUpdates = append(semanticTypeUpdates, addUpdate)
 		}
-		add := &ColumnUpdate{
-			SemanticTypes: []string{addKey},
-			Indices:       v.addIndices,
-		}
+
 		var removeKey string
 		if len(v.removeIndices) > 0 {
 			removeKey = k
+			remove := &ColumnUpdate{
+				SemanticTypes: []string{removeKey},
+				Indices:       v.removeIndices,
+			}
+			removeUpdate := NewRemoveSemanticTypeStep("", remove)
+			semanticTypeUpdates = append(semanticTypeUpdates, removeUpdate)
 		}
-		remove := &ColumnUpdate{
-			SemanticTypes: []string{removeKey},
-			Indices:       v.removeIndices,
-		}
-		semanticTypeUpdate, err := NewUpdateSemanticTypeStep("", add, remove)
-		if err != nil {
-			return nil, err
-		}
-		semanticTypeUpdates = append(semanticTypeUpdates, semanticTypeUpdate)
 	}
 	return semanticTypeUpdates, nil
 }

--- a/primitive/compute/description/preprocessing_test.go
+++ b/primitive/compute/description/preprocessing_test.go
@@ -61,32 +61,32 @@ func TestCreateUserDatasetPipeline(t *testing.T) {
 		t.Logf("Step %d: %s", i, step.GetPrimitive().GetPrimitive().GetPythonPath())
 	}
 
-	// assert first step is denorm, next 4 are wrappers
-	pythonPath := pipeline.GetSteps()[0].GetPrimitive().GetPrimitive().GetPythonPath()
+	// denorm and the 4 are wrapper steps come after the wrapped primitives (requirement of d3m runtime)
+	pythonPath := pipeline.GetSteps()[3].GetPrimitive().GetPrimitive().GetPythonPath()
 	assert.Equal(t, "d3m.primitives.data_transformation.denormalize.Common", pythonPath)
-	for i := 1; i < 3; i++ {
+	for i := 4; i < 7; i++ {
 		pythonPath := pipeline.GetSteps()[i].GetPrimitive().GetPrimitive().GetPythonPath()
 		assert.Equal(t, "d3m.primitives.operator.dataset_map.DataFrameCommon", pythonPath)
 	}
 	// next is the inference step, which doesn't have a primitive associated with it
-	assert.NotNil(t, pipeline.GetSteps()[4].GetPlaceholder())
+	assert.NotNil(t, pipeline.GetSteps()[7].GetPlaceholder())
 
 	// add semantic type integer to cols 1,3
-	assert.Equal(t, int32(5), pipeline.GetSteps()[1].GetPrimitive().GetHyperparams()["primitive"].GetPrimitive().GetData())
-	hyperParams := pipeline.GetSteps()[5].GetPrimitive().GetHyperparams()
+	assert.Equal(t, int32(0), pipeline.GetSteps()[4].GetPrimitive().GetHyperparams()["primitive"].GetPrimitive().GetData())
+	hyperParams := pipeline.GetSteps()[0].GetPrimitive().GetHyperparams()
 	assert.Equal(t, []int64{1, 3}, ConvertToIntArray(hyperParams["columns"].GetValue().GetData().GetRaw().GetList()))
 	assert.Equal(t, []string{"http://schema.org/Integer"}, ConvertToStringArray(hyperParams["semantic_types"].GetValue().GetData().GetRaw().GetList()))
 
 	// remove semantic type categorical from cols 1,3
-	assert.Equal(t, int32(6), pipeline.GetSteps()[2].GetPrimitive().GetHyperparams()["primitive"].GetPrimitive().GetData())
-	hyperParams = pipeline.GetSteps()[6].GetPrimitive().GetHyperparams()
+	assert.Equal(t, int32(1), pipeline.GetSteps()[5].GetPrimitive().GetHyperparams()["primitive"].GetPrimitive().GetData())
+	hyperParams = pipeline.GetSteps()[1].GetPrimitive().GetHyperparams()
 	assert.Equal(t, []int64{1, 3}, ConvertToIntArray(hyperParams["columns"].GetValue().GetData().GetRaw().GetList()))
 	assert.Equal(t, []string{"https://metadata.datadrivendiscovery.org/types/CategoricalData"},
 		ConvertToStringArray(hyperParams["semantic_types"].GetValue().GetData().GetRaw().GetList()))
 
 	// remove column from index two
-	assert.Equal(t, int32(7), pipeline.GetSteps()[3].GetPrimitive().GetHyperparams()["primitive"].GetPrimitive().GetData())
-	hyperParams = pipeline.GetSteps()[7].GetPrimitive().GetHyperparams()
+	assert.Equal(t, int32(2), pipeline.GetSteps()[6].GetPrimitive().GetHyperparams()["primitive"].GetPrimitive().GetData())
+	hyperParams = pipeline.GetSteps()[2].GetPrimitive().GetHyperparams()
 	assert.Equal(t, []int64{2}, ConvertToIntArray(hyperParams["columns"].GetValue().GetData().GetRaw().GetList()))
 
 	assert.NoError(t, err)

--- a/primitive/compute/description/preprocessing_test.go
+++ b/primitive/compute/description/preprocessing_test.go
@@ -55,25 +55,38 @@ func TestCreateUserDatasetPipeline(t *testing.T) {
 
 	pipeline, err := CreateUserDatasetPipeline(
 		"test_user_pipeline", "a test user pipeline", variables, "test_target", []string{"test_var_0", "test_var_1", "test_var_3"}, nil)
+	assert.Equal(t, 8, len(pipeline.GetSteps()))
 
-	// assert 1st is a semantic type update
-	hyperParams := pipeline.GetSteps()[1].GetPrimitive().GetHyperparams()
-	assert.Equal(t, []int64{1, 3}, ConvertToIntArray(hyperParams["add_columns"].GetValue().GetData().GetRaw().GetList()))
-	assert.Equal(t, []string{"http://schema.org/Integer"}, ConvertToStringArray(hyperParams["add_types"].GetValue().GetData().GetRaw().GetList()))
-	assert.Equal(t, []int64{}, ConvertToIntArray(hyperParams["remove_columns"].GetValue().GetData().GetRaw().GetList()))
-	assert.Equal(t, []string{""}, ConvertToStringArray(hyperParams["remove_types"].GetValue().GetData().GetRaw().GetList()))
+	for i, step := range pipeline.GetSteps() {
+		t.Logf("Step %d: %s", i, step.GetPrimitive().GetPrimitive().GetPythonPath())
+	}
 
-	// assert 2nd is a semantic type update
-	hyperParams = pipeline.GetSteps()[2].GetPrimitive().GetHyperparams()
-	assert.Equal(t, []int64{}, ConvertToIntArray(hyperParams["add_columns"].GetValue().GetData().GetRaw().GetList()))
-	assert.Equal(t, []string{""}, ConvertToStringArray(hyperParams["add_types"].GetValue().GetData().GetRaw().GetList()))
-	assert.Equal(t, []int64{1, 3}, ConvertToIntArray(hyperParams["remove_columns"].GetValue().GetData().GetRaw().GetList()))
+	// assert first step is denorm, next 4 are wrappers
+	pythonPath := pipeline.GetSteps()[0].GetPrimitive().GetPrimitive().GetPythonPath()
+	assert.Equal(t, "d3m.primitives.data_transformation.denormalize.Common", pythonPath)
+	for i := 1; i < 3; i++ {
+		pythonPath := pipeline.GetSteps()[i].GetPrimitive().GetPrimitive().GetPythonPath()
+		assert.Equal(t, "d3m.primitives.operator.dataset_map.DataFrameCommon", pythonPath)
+	}
+	// next is the inference step, which doesn't have a primitive associated with it
+	assert.NotNil(t, pipeline.GetSteps()[4].GetPlaceholder())
+
+	// add semantic type integer to cols 1,3
+	assert.Equal(t, int32(5), pipeline.GetSteps()[1].GetPrimitive().GetHyperparams()["primitive"].GetPrimitive().GetData())
+	hyperParams := pipeline.GetSteps()[5].GetPrimitive().GetHyperparams()
+	assert.Equal(t, []int64{1, 3}, ConvertToIntArray(hyperParams["columns"].GetValue().GetData().GetRaw().GetList()))
+	assert.Equal(t, []string{"http://schema.org/Integer"}, ConvertToStringArray(hyperParams["semantic_types"].GetValue().GetData().GetRaw().GetList()))
+
+	// remove semantic type categorical from cols 1,3
+	assert.Equal(t, int32(6), pipeline.GetSteps()[2].GetPrimitive().GetHyperparams()["primitive"].GetPrimitive().GetData())
+	hyperParams = pipeline.GetSteps()[6].GetPrimitive().GetHyperparams()
+	assert.Equal(t, []int64{1, 3}, ConvertToIntArray(hyperParams["columns"].GetValue().GetData().GetRaw().GetList()))
 	assert.Equal(t, []string{"https://metadata.datadrivendiscovery.org/types/CategoricalData"},
-		ConvertToStringArray(hyperParams["remove_types"].GetValue().GetData().GetRaw().GetList()))
+		ConvertToStringArray(hyperParams["semantic_types"].GetValue().GetData().GetRaw().GetList()))
 
-	// assert 3rd step is column remove and index two was remove
-	hyperParams = pipeline.GetSteps()[3].GetPrimitive().GetHyperparams()
-	assert.Equal(t, "", hyperParams["resource_id"].GetValue().GetData().GetRaw().GetString_())
+	// remove column from index two
+	assert.Equal(t, int32(7), pipeline.GetSteps()[3].GetPrimitive().GetHyperparams()["primitive"].GetPrimitive().GetData())
+	hyperParams = pipeline.GetSteps()[7].GetPrimitive().GetHyperparams()
 	assert.Equal(t, []int64{2}, ConvertToIntArray(hyperParams["columns"].GetValue().GetData().GetRaw().GetList()))
 
 	assert.NoError(t, err)

--- a/primitive/compute/description/primitive_steps.go
+++ b/primitive/compute/description/primitive_steps.go
@@ -165,24 +165,12 @@ func NewDatasetToDataframeStep() *StepData {
 	)
 }
 
-// ColumnUpdate defines a set of column indices to add/remvoe
-// a set of semantic types to/from.
-type ColumnUpdate struct {
-	Indices       []int
-	SemanticTypes []string
-}
+//NewDatasetWrapperStep creates a primitive that wraps a dataframe primitive such that it can be
+// used as a datset primitive in the pipeline prepend.
+func NewDatasetWrapperStep(dataframePrimitive *StepData, resourceID string) *StepData {
 
-// NewUpdateSemanticTypeStep adds and removes semantic data values from an input
-// dataset.  An add of (1, 2), ("type a", "type b") would result in "type a" and "type b"
-// being added to index 1 and 2.  Leaving the resource ID
-// as the empty value allows the primitive to infer the main resource from the
-// the dataset.
-func NewUpdateSemanticTypeStep(resourceID string, add *ColumnUpdate, remove *ColumnUpdate) (*StepData, error) {
 	hyperparams := map[string]interface{}{
-		"add_columns":    add.Indices,
-		"add_types":      add.SemanticTypes,
-		"remove_columns": remove.Indices,
-		"remove_types":   remove.SemanticTypes,
+		"primitive": dataframePrimitive,
 	}
 	if resourceID != "" {
 		hyperparams["resource_id"] = resourceID
@@ -190,15 +178,68 @@ func NewUpdateSemanticTypeStep(resourceID string, add *ColumnUpdate, remove *Col
 
 	return NewStepDataWithHyperparameters(
 		&pipeline.Primitive{
-			Id:         "98c79128-555a-4a6b-85fb-d4f4064c94ab",
-			Version:    "0.2.0",
-			Name:       "Semantic type updater",
-			PythonPath: "d3m.primitives.data_transformation.update_semantic_types.DatasetCommon",
-			Digest:     "85b946aa6123354fe51a288c3be56aaca82e76d4071c1edc13be6f9e0e100144",
+			Id:         "5bef5738-1638-48d6-9935-72445f0eecdc",
+			Version:    "0.1.0",
+			Name:       "Map DataFrame resources to new resources using provided primitive",
+			PythonPath: "d3m.primitives.operator.dataset_map.DataFrameCommon",
+			Digest:     "b602026372cab83090708ad7f1c8e8e9d48cd03b1841f59b52b59244727a4aa0",
 		},
 		[]string{"produce"},
 		hyperparams,
-	), nil
+	)
+}
+
+// ColumnUpdate defines a set of column indices to add/remvoe
+// a set of semantic types to/from.
+type ColumnUpdate struct {
+	Indices       []int
+	SemanticTypes []string
+}
+
+// NewAddSemanticTypeStep adds semantic data values to an input
+// dataset.  An add of (1, 2), ("type a", "type b") would result in "type a" and "type b"
+// being added to index 1 and 2.  Leaving the resource ID
+// as the empty value allows the primitive to infer the main resource from the
+// the dataset.
+func NewAddSemanticTypeStep(resourceID string, add *ColumnUpdate) *StepData {
+	step := NewStepDataWithHyperparameters(
+		&pipeline.Primitive{
+			Id:         "d7e14b12-abeb-42d8-942f-bdb077b4fd37",
+			Version:    "0.1.0",
+			Name:       "Add semantic types to columns",
+			PythonPath: "d3m.primitives.data_transformation.add_semantic_types.DataFrameCommon",
+			Digest:     "f165abd067b013c18459729c20c082efe7f450d98775e4b1579716f4fd988e76",
+		},
+		[]string{"produce"},
+		map[string]interface{}{
+			"columns":        add.Indices,
+			"semantic_types": add.SemanticTypes,
+		},
+	)
+	return NewDatasetWrapperStep(step, resourceID)
+}
+
+// NewRemoveSemanticTypeStep removes semantic data values from an input
+// dataset.  A remove of (1, 2), ("type a", "type b") would result in "type a" and "type b"
+// being removed from index 1 and 2.  Leaving the resource ID
+// as the empty value allows the primitive to infer the main resource from the
+// the dataset.
+func NewRemoveSemanticTypeStep(resourceID string, remove *ColumnUpdate) *StepData {
+	step := NewStepDataWithHyperparameters(
+		&pipeline.Primitive{
+			Id:         "3002bc5b-fa47-4a3d-882e-a8b5f3d756aa",
+			Version:    "0.1.0",
+			Name:       "Remove semantic types from columns",
+			PythonPath: "d3m.primitives.data_transformation.remove_semantic_types.DataFrameCommon",
+			Digest:     "ff48930a123697994f8b606b8a353c7e60aaf21738f4fd1a2611d8d1eb4a349a",
+		},
+		[]string{"produce"},
+		map[string]interface{}{
+			"columns":        remove.Indices,
+			"semantic_types": remove.SemanticTypes,
+		},
+	)
+	return NewDatasetWrapperStep(step, resourceID)
 }
 
 // NewDenormalizeStep denormalize data that is contained in multiple resource files.
@@ -209,7 +250,7 @@ func NewDenormalizeStep() *StepData {
 			Version:    "0.2.0",
 			Name:       "Denormalize datasets",
 			PythonPath: "d3m.primitives.data_transformation.denormalize.Common",
-			Digest:     "c39e3436373aed1944edbbc9b1cf24af5c71919d73bf0bb545cba0b685812df1",
+			Digest:     "6a80776d244347f0d29f4358df1cd0286c25f67e03a7e2ee517c6e853e6a9d1f",
 		},
 		[]string{"produce"},
 	)
@@ -234,25 +275,23 @@ func NewColumnParserStep() *StepData {
 // are specified by name and the match is case insensitive.  Leaving the resource ID
 // as the empty value allows the primitive to infer the main resource from the
 // the dataset.
-func NewRemoveColumnsStep(resourceID string, colIndices []int) (*StepData, error) {
-	hyperparams := map[string]interface{}{
-		"columns": colIndices,
-	}
-	if resourceID != "" {
-		hyperparams["resource_id"] = resourceID
-	}
-
-	return NewStepDataWithHyperparameters(
+func NewRemoveColumnsStep(resourceID string, colIndices []int) *StepData {
+	step := NewStepDataWithHyperparameters(
 		&pipeline.Primitive{
-			Id:         "2eeff053-395a-497d-88db-7374c27812e6",
-			Version:    "0.2.0",
+			Id:         "3b09ba74-cc90-4f22-9e0a-0cf4f29a7e28",
+			Version:    "0.1.0",
 			Name:       "Column remover",
-			PythonPath: "d3m.primitives.data_transformation.remove_columns.DatasetCommon",
-			Digest:     "85b946aa6123354fe51a288c3be56aaca82e76d4071c1edc13be6f9e0e100144",
+			PythonPath: "d3m.primitives.data_transformation.remove_columns.DataFrameCommon",
+			Digest:     "d2d01abb8d2183baf0204a9ecb8fefdb43683547a1e26049bf4bf81af1137fa3",
 		},
 		[]string{"produce"},
-		hyperparams,
-	), nil
+		map[string]interface{}{
+			"columns": colIndices,
+		},
+	)
+
+	// Wrap the dataframe based primitive in the dataset adapter
+	return NewDatasetWrapperStep(step, resourceID)
 }
 
 // NewTermFilterStep creates a primitive step that filters dataset rows based on a match against a
@@ -260,27 +299,24 @@ func NewRemoveColumnsStep(resourceID string, colIndices []int) (*StepData, error
 // as the empty value allows the primitive to infer the main resource from the
 // the dataset.
 func NewTermFilterStep(resourceID string, colindex int, inclusive bool, terms []string, matchWhole bool) *StepData {
-	hyperparams := map[string]interface{}{
-		"column":      colindex,
-		"inclusive":   inclusive,
-		"terms":       terms,
-		"match_whole": matchWhole,
-	}
-	if resourceID != "" {
-		hyperparams["resource_id"] = resourceID
-	}
-
-	return NewStepDataWithHyperparameters(
+	step := NewStepDataWithHyperparameters(
 		&pipeline.Primitive{
 			Id:         "622893c7-42fc-4561-a6f6-071fb85d610a",
 			Version:    "0.1.0",
 			Name:       "Term list dataset filter",
-			PythonPath: "d3m.primitives.datasets.TermFilter",
-			Digest:     "",
+			PythonPath: "d3m.primitives.data_preprocessing.term_filter.DataFrameCommon",
+			Digest:     "48ba9165ceddd92f740bfae8bbcb894986d3dffb430ee3c2269e7952bb2aad0d",
 		},
 		[]string{"produce"},
-		hyperparams,
+		map[string]interface{}{
+			"column":      colindex,
+			"inclusive":   inclusive,
+			"terms":       terms,
+			"match_whole": matchWhole,
+		},
 	)
+	// Wrap the dataframe based primitive in the dataset adapter
+	return NewDatasetWrapperStep(step, resourceID)
 }
 
 // NewRegexFilterStep creates a primitive step that filter dataset rows based on a regex match.
@@ -292,21 +328,19 @@ func NewRegexFilterStep(resourceID string, colindex int, inclusive bool, regex s
 		"inclusive": inclusive,
 		"regex":     regex,
 	}
-	if resourceID != "" {
-		hyperparams["resource_id"] = resourceID
-	}
-
-	return NewStepDataWithHyperparameters(
+	step := NewStepDataWithHyperparameters(
 		&pipeline.Primitive{
-			Id:         "d1b4c4b7-63ba-4ee6-ab30-035157cccf22",
+			Id:         "cf73bb3d-170b-4ba9-9ead-3dd4b4524b61",
 			Version:    "0.1.0",
 			Name:       "Regex dataset filter",
-			PythonPath: "d3m.primitives.datasets.RegexFilter",
-			Digest:     "",
+			PythonPath: "d3m.primitives.data_preprocessing.regex_filter.DataFrameCommon",
+			Digest:     "b6594dce51b2d16d6468cea45619750bc73fcaf9731d52afa1328398b3d54371",
 		},
 		[]string{"produce"},
 		hyperparams,
 	)
+	// Wrap the dataframe based primitive in the dataset adapter
+	return NewDatasetWrapperStep(step, resourceID)
 }
 
 // NewNumericRangeFilterStep creates a primitive step that filters dataset rows based on an
@@ -314,28 +348,25 @@ func NewRegexFilterStep(resourceID string, colindex int, inclusive bool, regex s
 // Leaving the resource ID as the empty value allows the primitive to infer the main resource from the
 // the dataset.
 func NewNumericRangeFilterStep(resourceID string, colindex int, inclusive bool, min float64, max float64, strict bool) *StepData {
-	hyperparams := map[string]interface{}{
-		"column":    colindex,
-		"inclusive": inclusive,
-		"min":       min,
-		"max":       max,
-		"strict":    strict,
-	}
-	if resourceID != "" {
-		hyperparams["resource_id"] = resourceID
-	}
-
-	return NewStepDataWithHyperparameters(
+	step := NewStepDataWithHyperparameters(
 		&pipeline.Primitive{
-			Id:         "8b1c1140-8c21-4f41-aeca-662b7d35aa29",
+			Id:         "8c246c78-3082-4ec9-844e-5c98fcc76f9d",
 			Version:    "0.1.0",
 			Name:       "Numeric range filter",
-			PythonPath: "d3m.primitives.datasets.NumericRangeFilter",
-			Digest:     "",
+			PythonPath: "d3m.primitives.data_preprocessing.numeric_range_filter.DataFrameCommon",
+			Digest:     "031e249edabb35dbd4e6d7453d1e149774678603dfc186d0a1a03c153b132101",
 		},
 		[]string{"produce"},
-		hyperparams,
+		map[string]interface{}{
+			"column":    colindex,
+			"inclusive": inclusive,
+			"min":       min,
+			"max":       max,
+			"strict":    strict,
+		},
 	)
+	// Wrap the dataframe based primitive in the dataset adapter
+	return NewDatasetWrapperStep(step, resourceID)
 }
 
 // NewTimeSeriesLoaderStep creates a primitive step that reads time series values using a dataframe


### PR DESCRIPTION
resolves #47 

Updates primitive steps to use dataset_map primitive along dataframe versions of column removal, semnatic type update and row filtering.  Also includes changes to ordering of wrapped primitives in pipeline to satisfy the d3m runtime.