### PR TITLE
adds categorical parsing for miranking pipeline to get hashed labels

### DIFF
--- a/primitive/compute/description/preprocessing.go
+++ b/primitive/compute/description/preprocessing.go
@@ -345,7 +345,11 @@ func CreateDataCleaningPipeline(name string, description string) (*pipeline.Pipe
 
 	steps := []Step{
 		NewDatasetToDataframeStep(map[string]DataRef{"inputs": &PipelineDataRef{0}}, []string{"produce"}),
-		NewColumnParserStep(map[string]DataRef{"inputs": &StepDataRef{0, "produce"}}, []string{"produce"}),
+		NewColumnParserStep(
+			map[string]DataRef{"inputs": &StepDataRef{0, "produce"}},
+			[]string{"produce"},
+			[]string{model.TA2IntegerType, model.TA2BooleanType, model.TA2RealType},
+		),
 		NewDataCleaningStep(map[string]DataRef{"inputs": &StepDataRef{1, "produce"}}, []string{"produce"}),
 	}
 
@@ -460,7 +464,12 @@ func CreateTargetRankingPipeline(name string, description string, target string,
 	offset += len(updateSemanticTypeStep)
 	steps = append(steps,
 		NewDatasetToDataframeStep(map[string]DataRef{"inputs": &StepDataRef{offset - 1, "produce"}}, []string{"produce"}),
-		NewColumnParserStep(map[string]DataRef{"inputs": &StepDataRef{offset, "produce"}}, []string{"produce"}),
+		NewColumnParserStep(
+			map[string]DataRef{"inputs": &StepDataRef{offset, "produce"}},
+			[]string{"produce"},
+			// inlcude categorical because the parser will hash all the values into ints, which the MIRanking primitive can handle
+			[]string{model.TA2IntegerType, model.TA2BooleanType, model.TA2RealType, model.TA2CategoricalType},
+		),
 		NewTargetRankingStep(map[string]DataRef{"inputs": &StepDataRef{offset + 1, "produce"}}, []string{"produce"}, targetIdx),
 	)
 	offset += 3

--- a/primitive/compute/description/primitive_steps.go
+++ b/primitive/compute/description/primitive_steps.go
@@ -361,7 +361,7 @@ func NewDataFrameFlattenStep(inputs map[string]DataRef, outputMethods []string) 
 
 // NewColumnParserStep takes obj/string columns in a dataframe and parses them into their
 // associated raw python types based on the attached d3m metadata.
-func NewColumnParserStep(inputs map[string]DataRef, outputMethods []string) *StepData {
+func NewColumnParserStep(inputs map[string]DataRef, outputMethods []string, types []string) *StepData {
 	return NewStepData(
 		&pipeline.Primitive{
 			Id:         "d510cb7a-1782-4f51-b44c-58f0236e47c7",
@@ -371,13 +371,7 @@ func NewColumnParserStep(inputs map[string]DataRef, outputMethods []string) *Ste
 			Digest:     "d95eb0ea8a5e6f9abc0965a97e9c4f5d8f74a3df591c11c4145faea3e581cd06",
 		},
 		outputMethods,
-		map[string]interface{}{
-			"parse_semantic_types": []string{
-				"http://schema.org/Boolean",
-				"http://schema.org/Integer",
-				"http://schema.org/Float",
-			},
-		},
+		map[string]interface{}{"parse_semantic_types": types},
 		inputs,
 	)
 }


### PR DESCRIPTION
The column parsing primitive will convert categorical labels that are strings into integers via hashing.  MIRanking can only handle float/bool/int values, so we need to make sure the hashing is applied.