### PR TITLE
Add Semantic Type To Join Pipeline

### DIFF
--- a/primitive/compute/description/preprocessing_test.go
+++ b/primitive/compute/description/preprocessing_test.go
@@ -498,7 +498,8 @@ func TestCreateGoatReversePipeline(t *testing.T) {
 }
 
 func TestCreateJoinPipeline(t *testing.T) {
-	pipeline, err := CreateJoinPipeline("join_test", "test join pipeline", "Doubles", "horsepower", 0.8)
+	pipeline, err := CreateJoinPipeline("join_test", "test join pipeline",
+		&model.Variable{DisplayName: "Doubles"}, &model.Variable{DisplayName: "horsepower"}, 0.8)
 	assert.NoError(t, err)
 
 	data, err := proto.Marshal(pipeline)


### PR DESCRIPTION
If the join column type gets updated by the user, the semantic type primitive is needed in the join pipeline otherwise the join may be invalid.