### PR TITLE
Skip preprocessing pipeilne due to errors in required common primitives

### DIFF
--- a/primitive/compute/description/preprocessing.go
+++ b/primitive/compute/description/preprocessing.go
@@ -60,16 +60,20 @@ func CreateUserDatasetPipeline(name string, description string, datasetDescripti
 
 	// determine if this is a timeseries dataset
 	isTimeseries := false
+	for _, v := range datasetDescription.AllFeatures {
+		if v.Grouping != nil && model.IsTimeSeries(v.Grouping.Type) {
+			isTimeseries = true
+			break
+		}
+	}
+
 	// TODO: CSV reader is currently not working correctly, so we need to disable the timeseries
 	// prepend and use the data as-is.  This is sufficient for now as the NK classification primitives
 	// run off the unmodified dataset (although they can be configured to long form)
 	// prend for now
-	// for _, v := range datasetDescription.AllFeatures {
-	// 	if v.Grouping != nil && model.IsTimeSeries(v.Grouping.Type) {
-	// 		isTimeseries = true
-	// 		break
-	// 	}
-	// }
+	if isTimeseries {
+		return nil, nil
+	}
 
 	// augment the dataset if needed
 	// need to track the initial dataref and set the offset properly

--- a/primitive/compute/ta3ta2.go
+++ b/primitive/compute/ta3ta2.go
@@ -96,7 +96,7 @@ var (
 	}
 	defaultTaskMetricMap = map[string]string{
 		"classification":               "f1Macro",
-		"regression":                   "rSquared",
+		"regression":                   "meanSquaredError",
 		"clustering":                   "normalizedMutualInformation",
 		"linkPrediction":               "accuracy",
 		"vertexNomination":             "accuracy",


### PR DESCRIPTION
Fixes uncharted-distil/distil#1173.  Ensures that the pipeline prepend is fully skipped for timeseries.  This can be undone once the CSV reader is fixed in common primitives.