### PR TITLE
Semantic type updates

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -351,7 +351,7 @@ func loadRawVariables(datasetPath string) (*model.DataResource, error) {
 			nil,
 			dataResource.Variables,
 			false)
-		variable.Type = model.StringType
+		variable.Type = model.UnknownType
 		dataResource.Variables = append(dataResource.Variables, variable)
 	}
 	return dataResource, nil

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -731,7 +731,7 @@ func AugmentVariablesFromHeader(dr *model.DataResource, header []string) []*mode
 		if i < len(augmentedVars) {
 			v := metaVars[i]
 			if v == nil {
-				v = model.NewVariable(i, c, c, c, model.StringType, model.StringType, "", []string{"attribute"}, model.VarRoleData, nil, augmentedVars, true)
+				v = model.NewVariable(i, c, c, c, model.UnknownType, model.UnknownType, "", []string{"attribute"}, model.VarRoleData, nil, augmentedVars, true)
 			}
 			augmentedVars[i] = v
 		}

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -555,7 +555,6 @@ func parseSchemaVariable(v *gabs.Container, existingVariables []*model.Variable,
 	if v.Path("colDisplayName").Data() != nil {
 		varDisplayName = v.Path("colDisplayName").Data().(string)
 	}
-
 	varType := ""
 	if v.Path("colType").Data() != nil {
 		varType = v.Path("colType").Data().(string)
@@ -592,6 +591,14 @@ func parseSchemaVariable(v *gabs.Container, existingVariables []*model.Variable,
 	varOriginalName := ""
 	if v.Path("varOriginalName").Data() != nil {
 		varOriginalName = v.Path("varOriginalName").Data().(string)
+	}
+
+	varOriginalType := ""
+	if v.Path("colOriginalType").Data() != nil {
+		varOriginalType = v.Path("colOriginalType").Data().(string)
+		varOriginalType = model.MapLLType(varOriginalType)
+	} else {
+		varOriginalType = varType
 	}
 
 	// parse the refersTo fields to properly serialize it if necessary
@@ -631,18 +638,47 @@ func parseSchemaVariable(v *gabs.Container, existingVariables []*model.Variable,
 		varDisplayName,
 		varOriginalName,
 		varType,
-		varType,
+		varOriginalType,
 		varDescription,
 		varRoles,
 		varDistilRole,
 		refersTo,
 		existingVariables,
 		normalizeName)
-	variable.SuggestedTypes = append(variable.SuggestedTypes, &model.SuggestedType{
-		Type:        variable.Type,
-		Probability: 0,
-		Provenance:  ProvenanceSchema,
-	})
+
+	// parse suggested types if present
+	suggestedTypesJSON := v.Path("suggestedTypes").Children()
+	suggestedTypes := make([]*model.SuggestedType, len(suggestedTypesJSON))
+	for i, suggestion := range suggestedTypesJSON {
+		stType := ""
+		if suggestion.Path("type").Data() != nil {
+			stType = suggestion.Path("type").Data().(string)
+		}
+		stProbability := -1.0
+		if suggestion.Path("probability").Data() != nil {
+			stProbability = suggestion.Path("probability").Data().(float64)
+		}
+		stProvenance := ""
+		if suggestion.Path("provenance").Data() != nil {
+			stProvenance = suggestion.Path("provenance").Data().(string)
+		}
+
+		suggestedTypes[i] = &model.SuggestedType{
+			Type:        stType,
+			Probability: stProbability,
+			Provenance:  stProvenance,
+		}
+	}
+
+	// no suggested type present so initialize it
+	if len(suggestedTypes) == 0 {
+		suggestedTypes = append(suggestedTypes, &model.SuggestedType{
+			Type:        variable.Type,
+			Probability: 0,
+			Provenance:  ProvenanceSchema,
+		})
+	}
+	variable.SuggestedTypes = suggestedTypes
 
 	return variable, nil
 }
@@ -854,13 +890,24 @@ func loadClassificationVariables(m *model.Metadata, normalizeVariableNames bool)
 		if err != nil {
 			return err
 		}
-		// get suggested types
-		suggestedTypes, err := parseSuggestedTypes(m, variable.Name, index, labels, probabilities)
-		if err != nil {
-			return err
+
+		// get suggested types if not loaded from schema
+		loaded := false
+		for _, suggestion := range variable.SuggestedTypes {
+			if suggestion.Provenance == ProvenanceSimon {
+				loaded = true
+				break
+			}
 		}
-		variable.SuggestedTypes = append(variable.SuggestedTypes, suggestedTypes...)
-		variable.Type = getHighestProbablySuggestedType(variable.SuggestedTypes)
+		if !loaded {
+			suggestedTypes, err := parseSuggestedTypes(m, variable.Name, index, labels, probabilities)
+			if err != nil {
+				return err
+			}
+			variable.SuggestedTypes = append(variable.SuggestedTypes, suggestedTypes...)
+			variable.Type = getHighestProbablySuggestedType(variable.SuggestedTypes)
+		}
+
 		m.DataResources[0].Variables = append(m.DataResources[0].Variables, variable)
 	}
 	return nil

--- a/model/schema_types.go
+++ b/model/schema_types.go
@@ -124,6 +124,8 @@ const (
 	// D3M runtime.  These should not be used/stored internally, but instead translated into the Distil
 	// types at the application boundaries.
 
+	//TA2AttributeType is the semantic type representing an attribute
+	TA2AttributeType = "https://metadata.datadrivendiscovery.org/types/Attribute"
 	// TA2StringType is the semantic type reprsenting a text/string
 	TA2StringType = "http://schema.org/Text"
 	// TA2IntegerType is the TA2 semantic type for an integer value

--- a/model/schema_types.go
+++ b/model/schema_types.go
@@ -124,8 +124,10 @@ const (
 	// D3M runtime.  These should not be used/stored internally, but instead translated into the Distil
 	// types at the application boundaries.
 
-	//TA2AttributeType is the semantic type representing an attribute
+	// TA2AttributeType is the semantic type representing an attribute
 	TA2AttributeType = "https://metadata.datadrivendiscovery.org/types/Attribute"
+	// TA2UnknownType is the semantic type representing the unknown field type
+	TA2UnknownType = "https://metadata.datadrivendiscovery.org/types/UnknownType"
 	// TA2StringType is the semantic type reprsenting a text/string
 	TA2StringType = "http://schema.org/Text"
 	// TA2IntegerType is the TA2 semantic type for an integer value
@@ -236,7 +238,7 @@ var (
 		ImageType:       TA2StringType,
 		TimestampType:   TA2TimeType,
 		TimeSeriesType:  TA2TimeSeriesType,
-		UnknownType:     TA2StringType,
+		UnknownType:     TA2UnknownType,
 	}
 
 	// Maps from Distil internal type to D3M dataset doc type

--- a/model/schema_types.go
+++ b/model/schema_types.go
@@ -184,6 +184,8 @@ const (
 	TimeSeriesSchemaType = "timeseries"
 	// TimestampSchemaType is the schema doc type for image data
 	TimestampSchemaType = "timestamp"
+	// UnknownSchemaType is the scehma type representing the unknown field type
+	UnknownSchemaType = "unknown"
 )
 
 var (
@@ -265,6 +267,7 @@ var (
 		ImageType:       ImageSchemaType,
 		TimeSeriesType:  TimeSeriesSchemaType,
 		TimestampType:   TimestampSchemaType,
+		UnknownType:     UnknownSchemaType,
 	}
 
 	// Maps from Lincoln Labs D3M dataset doc type to Distil internal type
@@ -282,6 +285,7 @@ var (
 		TimestampSchemaType:      TimestampType,
 		TextSchemaTypeDeprecated: StringType,
 		StringSchemaType:         StringType,
+		UnknownSchemaType:        UnknownType,
 	}
 
 	// Maps from Simon type to Distil internal type

--- a/primitive/compute/description/fully_specified.go
+++ b/primitive/compute/description/fully_specified.go
@@ -224,7 +224,7 @@ func CreateTargetRankingPipeline(name string, description string, target string,
 
 	// ranking is dependent on user updated semantic types, so we need to make sure we apply
 	// those to the original data
-	updateSemanticTypeStep, err := createUpdateSemanticTypes(features, map[string]bool{}, offset)
+	updateSemanticTypeStep, err := createUpdateSemanticTypes(target, features, map[string]bool{}, offset)
 	if err != nil {
 		return nil, err
 	}

--- a/primitive/compute/description/preprocessing.go
+++ b/primitive/compute/description/preprocessing.go
@@ -225,7 +225,7 @@ func createUpdateSemanticTypes(target string, allFeatures []*model.Variable, sel
 			}
 
 			// update all non target to attribute
-			if v.DistilRole != model.RoleIndex && !strings.EqualFold(v.Name, target) {
+			if v.SelectedRole != model.RoleIndex && !strings.EqualFold(v.Name, target) {
 				attributes = append(attributes, v.Index)
 			}
 		}

--- a/primitive/compute/description/preprocessing.go
+++ b/primitive/compute/description/preprocessing.go
@@ -206,6 +206,11 @@ func createUpdateSemanticTypes(target string, allFeatures []*model.Variable, sel
 			if addType == "" {
 				return nil, errors.Errorf("variable `%s` internal type `%s` can't be mapped to ta2", v.Name, v.Type)
 			}
+			// unknown type must not be passed to TA2
+			if addType == model.TA2UnknownType {
+				addType = model.TA2StringType
+			}
+
 			removeType := model.MapTA2Type(v.OriginalType)
 			if removeType == "" {
 				return nil, errors.Errorf("remove variable `%s` internal type `%s` can't be mapped to ta2", v.Name, v.OriginalType)

--- a/primitive/compute/description/preprocessing.go
+++ b/primitive/compute/description/preprocessing.go
@@ -112,7 +112,7 @@ func CreateUserDatasetPipeline(name string, description string, datasetDescripti
 	}
 
 	// create the semantic type update primitive
-	updateSemanticTypes, err := createUpdateSemanticTypes(datasetDescription.AllFeatures, selectedSet, offset)
+	updateSemanticTypes, err := createUpdateSemanticTypes(datasetDescription.TargetFeature.Name, datasetDescription.AllFeatures, selectedSet, offset)
 	if err != nil {
 		return nil, err
 	}
@@ -194,7 +194,7 @@ func newUpdate() *update {
 	}
 }
 
-func createUpdateSemanticTypes(allFeatures []*model.Variable, selectedSet map[string]bool, offset int) ([]Step, error) {
+func createUpdateSemanticTypes(target string, allFeatures []*model.Variable, selectedSet map[string]bool, offset int) ([]Step, error) {
 	// create maps of (semantic type, index list) - primitive allows for semantic types to be added to /
 	// remove from multiple columns in a single operation
 	updateMap := map[string]*update{}
@@ -225,7 +225,9 @@ func createUpdateSemanticTypes(allFeatures []*model.Variable, selectedSet map[st
 			}
 
 			// update all non target to attribute
-			attributes = append(attributes, v.Index)
+			if v.DistilRole != model.RoleIndex && !strings.EqualFold(v.Name, target) {
+				attributes = append(attributes, v.Index)
+			}
 		}
 	}
 

--- a/primitive/compute/description/preprocessing.go
+++ b/primitive/compute/description/preprocessing.go
@@ -223,10 +223,10 @@ func createUpdateSemanticTypes(allFeatures []*model.Variable, selectedSet map[st
 				}
 				updateMap[removeType].removeIndices = append(updateMap[removeType].removeIndices, v.Index)
 			}
-		}
 
-		// update all non target to attribute
-		attributes = append(attributes, v.Index)
+			// update all non target to attribute
+			attributes = append(attributes, v.Index)
+		}
 	}
 
 	// Copy the created maps into the column update structure used by the primitive.  Force

--- a/primitive/compute/description/preprocessing_test.go
+++ b/primitive/compute/description/preprocessing_test.go
@@ -314,7 +314,7 @@ func TestCreateUserDatasetPipeline(t *testing.T) {
 	hyperParams = pipeline.GetSteps()[11].GetPrimitive().GetHyperparams()
 	assert.Equal(t, []int64{2}, ConvertToIntArray(hyperParams["columns"].GetValue().GetData().GetRaw().GetList()))
 
-	assert.Equal(t, int32(10), pipeline.GetSteps()[12].GetPrimitive().GetHyperparams()["primitive"].GetPrimitive().GetData())
+	assert.Equal(t, int32(11), pipeline.GetSteps()[12].GetPrimitive().GetHyperparams()["primitive"].GetPrimitive().GetData())
 	inputs = pipeline.GetSteps()[12].GetPrimitive().GetArguments()["inputs"].GetContainer().GetData()
 	assert.Equal(t, "steps.10.produce", inputs)
 
@@ -365,9 +365,45 @@ func TestCreateUserDatasetEmpty(t *testing.T) {
 			SelectedFeatures: []string{"test_var_0"},
 			Filters:          nil,
 		}, nil)
-
-	assert.Nil(t, pipeline)
+	assert.Equal(t, 8, len(pipeline.GetSteps()))
 	assert.Nil(t, err)
+
+	pythonPath := pipeline.GetSteps()[0].GetPrimitive().GetPrimitive().GetPythonPath()
+	assert.Equal(t, "d3m.primitives.data_transformation.denormalize.Common", pythonPath)
+	inputs := pipeline.GetSteps()[0].GetPrimitive().GetArguments()["inputs"].GetContainer().GetData()
+	assert.Equal(t, "inputs.0", inputs)
+
+	pythonPath = pipeline.GetSteps()[1].GetPrimitive().GetPrimitive().GetPythonPath()
+	assert.Equal(t, "d3m.primitives.data_transformation.column_parser.Common", pythonPath)
+
+	pythonPath = pipeline.GetSteps()[2].GetPrimitive().GetPrimitive().GetPythonPath()
+	assert.Equal(t, "d3m.primitives.operator.dataset_map.DataFrameCommon", pythonPath)
+	assert.Equal(t, int32(1), pipeline.GetSteps()[2].GetPrimitive().GetHyperparams()["primitive"].GetPrimitive().GetData())
+	inputs = pipeline.GetSteps()[2].GetPrimitive().GetArguments()["inputs"].GetContainer().GetData()
+	assert.Equal(t, "steps.0.produce", inputs)
+
+	pythonPath = pipeline.GetSteps()[3].GetPrimitive().GetPrimitive().GetPythonPath()
+	assert.Equal(t, "d3m.primitives.data_cleaning.data_cleaning.Datacleaning", pythonPath)
+
+	pythonPath = pipeline.GetSteps()[4].GetPrimitive().GetPrimitive().GetPythonPath()
+	assert.Equal(t, "d3m.primitives.operator.dataset_map.DataFrameCommon", pythonPath)
+	assert.Equal(t, int32(3), pipeline.GetSteps()[4].GetPrimitive().GetHyperparams()["primitive"].GetPrimitive().GetData())
+	inputs = pipeline.GetSteps()[4].GetPrimitive().GetArguments()["inputs"].GetContainer().GetData()
+	assert.Equal(t, "steps.2.produce", inputs)
+
+	// add attrobute semantic type
+	hyperParams := pipeline.GetSteps()[5].GetPrimitive().GetHyperparams()
+	assert.Equal(t, []int64{0}, ConvertToIntArray(hyperParams["columns"].GetValue().GetData().GetRaw().GetList()))
+	assert.Equal(t, []string{"https://metadata.datadrivendiscovery.org/types/Attribute"}, ConvertToStringArray(hyperParams["semantic_types"].GetValue().GetData().GetRaw().GetList()))
+
+	assert.Equal(t, int32(5), pipeline.GetSteps()[6].GetPrimitive().GetHyperparams()["primitive"].GetPrimitive().GetData())
+	inputs = pipeline.GetSteps()[6].GetPrimitive().GetArguments()["inputs"].GetContainer().GetData()
+	assert.Equal(t, "steps.4.produce", inputs)
+
+	// next is the inference step, which doesn't have a primitive associated with it
+	assert.NotNil(t, pipeline.GetSteps()[7].GetPlaceholder())
+	inputs = pipeline.GetSteps()[7].GetPlaceholder().GetInputs()[0].GetData()
+	assert.Equal(t, "steps.6.produce", inputs)
 }
 
 func TestCreatePCAFeaturesPipeline(t *testing.T) {

--- a/primitive/compute/description/preprocessing_test.go
+++ b/primitive/compute/description/preprocessing_test.go
@@ -257,7 +257,7 @@ func TestCreateUserDatasetPipeline(t *testing.T) {
 		},
 		nil,
 	)
-	assert.Equal(t, 12, len(pipeline.GetSteps()))
+	assert.Equal(t, 14, len(pipeline.GetSteps()))
 
 	pythonPath := pipeline.GetSteps()[0].GetPrimitive().GetPrimitive().GetPythonPath()
 	assert.Equal(t, "d3m.primitives.data_transformation.denormalize.Common", pythonPath)
@@ -301,18 +301,27 @@ func TestCreateUserDatasetPipeline(t *testing.T) {
 	inputs = pipeline.GetSteps()[8].GetPrimitive().GetArguments()["inputs"].GetContainer().GetData()
 	assert.Equal(t, "steps.6.produce", inputs)
 
-	// remove column from index two
+	// add attrobute semantic type
 	hyperParams = pipeline.GetSteps()[9].GetPrimitive().GetHyperparams()
-	assert.Equal(t, []int64{2}, ConvertToIntArray(hyperParams["columns"].GetValue().GetData().GetRaw().GetList()))
+	assert.Equal(t, []int64{0, 1, 3}, ConvertToIntArray(hyperParams["columns"].GetValue().GetData().GetRaw().GetList()))
+	assert.Equal(t, []string{"https://metadata.datadrivendiscovery.org/types/Attribute"}, ConvertToStringArray(hyperParams["semantic_types"].GetValue().GetData().GetRaw().GetList()))
 
 	assert.Equal(t, int32(9), pipeline.GetSteps()[10].GetPrimitive().GetHyperparams()["primitive"].GetPrimitive().GetData())
 	inputs = pipeline.GetSteps()[10].GetPrimitive().GetArguments()["inputs"].GetContainer().GetData()
 	assert.Equal(t, "steps.8.produce", inputs)
 
-	// next is the inference step, which doesn't have a primitive associated with it
-	assert.NotNil(t, pipeline.GetSteps()[11].GetPlaceholder())
-	inputs = pipeline.GetSteps()[11].GetPlaceholder().GetInputs()[0].GetData()
+	// remove column from index two
+	hyperParams = pipeline.GetSteps()[11].GetPrimitive().GetHyperparams()
+	assert.Equal(t, []int64{2}, ConvertToIntArray(hyperParams["columns"].GetValue().GetData().GetRaw().GetList()))
+
+	assert.Equal(t, int32(10), pipeline.GetSteps()[12].GetPrimitive().GetHyperparams()["primitive"].GetPrimitive().GetData())
+	inputs = pipeline.GetSteps()[12].GetPrimitive().GetArguments()["inputs"].GetContainer().GetData()
 	assert.Equal(t, "steps.10.produce", inputs)
+
+	// next is the inference step, which doesn't have a primitive associated with it
+	assert.NotNil(t, pipeline.GetSteps()[13].GetPlaceholder())
+	inputs = pipeline.GetSteps()[13].GetPlaceholder().GetInputs()[0].GetData()
+	assert.Equal(t, "steps.12.produce", inputs)
 
 	assert.NoError(t, err)
 }

--- a/primitive/compute/description/primitive_steps.go
+++ b/primitive/compute/description/primitive_steps.go
@@ -23,12 +23,6 @@ import (
 // NewSimonStep creates a SIMON data classification step.  It examines an input
 // dataframe, and assigns types to the columns based on the exposed metadata.
 func NewSimonStep(inputs map[string]DataRef, outputMethods []string) *StepData {
-	// since Simon has fit & produce, need to set the params from
-	// set_training_data. In this case, outputs is not used.
-	if inputs["inputs"] != nil && inputs["outputs"] == nil {
-		inputs["outputs"] = inputs["inputs"]
-	}
-
 	return NewStepData(
 		&pipeline.Primitive{
 			Id:         "d2fa8df2-6517-3c26-bafc-87b701c4043a",


### PR DESCRIPTION
Added support for the unknown type. Also added the attribute semantic type to columns being used in pipelines since the new partial schema no longer has attribute type for every column.

The schema parsing code had to be updated to parse the original types and type suggestions. This enabled the propagation of the unknown type properly.