### PR TITLE
Timeseries count fix

### DIFF
--- a/primitive/compute/description/fully_specified.go
+++ b/primitive/compute/description/fully_specified.go
@@ -31,13 +31,13 @@ func CreateSlothPipeline(name string, description string, timeColumn string, val
 	steps := make([]Step, 0)
 	steps = append(steps, NewTimeseriesFormatterStep(map[string]DataRef{"inputs": &PipelineDataRef{0}}, []string{"produce"}, compute.DefaultResourceID, -1))
 
-	offset := 0
+	offset := 1
 	updateSemanticTypes, err := createUpdateSemanticTypes("", timeSeriesFeatures, nil, offset)
 	if err != nil {
 		return nil, err
 	}
 	steps = append(steps, updateSemanticTypes...)
-	offset += len(updateSemanticTypes)
+	offset += len(updateSemanticTypes) - 1
 
 	steps = append(steps, NewDatasetToDataframeStep(map[string]DataRef{"inputs": &StepDataRef{offset, "produce"}}, []string{"produce"}))
 	steps = append(steps, NewGroupingFieldComposeStep(

--- a/primitive/compute/description/fully_specified.go
+++ b/primitive/compute/description/fully_specified.go
@@ -28,9 +28,6 @@ import (
 func CreateSlothPipeline(name string, description string, timeColumn string, valueColumn string,
 	timeSeriesFeatures []*model.Variable) (*pipeline.PipelineDescription, error) {
 
-	inputs := []string{"inputs"}
-	outputs := []DataRef{&StepDataRef{3, "produce"}}
-
 	steps := make([]Step, 0)
 	steps = append(steps, NewTimeseriesFormatterStep(map[string]DataRef{"inputs": &PipelineDataRef{0}}, []string{"produce"}, compute.DefaultResourceID, -1))
 
@@ -51,6 +48,9 @@ func CreateSlothPipeline(name string, description string, timeColumn string, val
 		"__grouping_key",
 	))
 	steps = append(steps, NewSlothStep(map[string]DataRef{"inputs": &StepDataRef{offset + 2, "produce"}}, []string{"produce"}))
+
+	inputs := []string{"inputs"}
+	outputs := []DataRef{&StepDataRef{len(steps) - 1, "produce"}}
 
 	pipeline, err := NewPipelineBuilder(name, description, inputs, outputs, steps).Compile()
 	if err != nil {

--- a/primitive/compute/description/preprocessing_test.go
+++ b/primitive/compute/description/preprocessing_test.go
@@ -468,8 +468,8 @@ func TestCreateUnicornPipeline(t *testing.T) {
 
 func TestCreateSlothPipeline(t *testing.T) {
 	timeSeriesVariables := []*model.Variable{
-		{Name: "time", Index: 0},
-		{Name: "value", Index: 1},
+		{Name: "time", Type: "string", OriginalType: "unknown", Index: 0},
+		{Name: "value", Type: "string", OriginalType: "unknown", Index: 1},
 	}
 
 	pipeline, err := CreateSlothPipeline("sloth_test", "test sloth object detection pipeline", "time", "value", timeSeriesVariables)


### PR DESCRIPTION
The Sloth pipeline has been updated to have the semantic type updating since the now default unknown types cause it to fail.