### PR TITLE
Schema Type Probability

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -677,9 +677,13 @@ func parseSchemaVariable(v *gabs.Container, existingVariables []*model.Variable,
 
 	// no suggested type present so initialize it
 	if len(suggestedTypes) == 0 {
+		probability := 1.0
+		if variable.Type == model.UnknownType {
+			probability = 0
+		}
 		suggestedTypes = append(suggestedTypes, &model.SuggestedType{
 			Type:        variable.Type,
-			Probability: 0,
+			Probability: probability,
 			Provenance:  ProvenanceSchema,
 		})
 	}


### PR DESCRIPTION
Fixes issue 116 for distil ingest. Everything defaults to unknown type if not in a schema file initially. This change makes it so that everything found in a schema file (that isn't unknown) has 1.0 probability. There is also code in there to adjust complex simon types to be probability * 1.5. Taken together, this should handle cases where the schema provides information and simon provides more depth.