### PR TITLE
Queue pipeline requests

### DIFF
--- a/primitive/compute/description/fully_specified.go
+++ b/primitive/compute/description/fully_specified.go
@@ -24,6 +24,8 @@ import (
 	"github.com/uncharted-distil/distil-compute/primitive/compute"
 )
 
+// FullySpecifiedPipeline wraps a fully specified pipeline along with
+// the fields which can be used to determine equivalent pipelines.
 type FullySpecifiedPipeline struct {
 	Pipeline         *pipeline.PipelineDescription
 	EquivalentValues []interface{}

--- a/primitive/compute/description/fully_specified.go
+++ b/primitive/compute/description/fully_specified.go
@@ -16,6 +16,7 @@
 package description
 
 import (
+	"encoding/json"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -29,6 +30,16 @@ import (
 type FullySpecifiedPipeline struct {
 	Pipeline         *pipeline.PipelineDescription
 	EquivalentValues []interface{}
+}
+
+// MarshalSteps marshals a pipeline description into a json representation.
+func MarshalSteps(step *pipeline.PipelineDescription) (string, error) {
+	stepJSON, err := json.Marshal(step)
+	if err != nil {
+		return "", errors.Wrapf(err, "unable to marshal steps")
+	}
+
+	return string(stepJSON), nil
 }
 
 // CreateImageClusteringPipeline creates a fully specified pipeline that will
@@ -56,9 +67,14 @@ func CreateImageClusteringPipeline(name string, description string, imageVariabl
 		return nil, err
 	}
 
+	pipelineJSON, err := MarshalSteps(pipeline)
+	if err != nil {
+		return nil, err
+	}
+
 	fullySpecified := &FullySpecifiedPipeline{
 		Pipeline:         pipeline,
-		EquivalentValues: []interface{}{pipeline},
+		EquivalentValues: []interface{}{pipelineJSON},
 	}
 	return fullySpecified, nil
 }
@@ -96,9 +112,14 @@ func CreateSlothPipeline(name string, description string, timeColumn string, val
 		return nil, err
 	}
 
+	pipelineJSON, err := MarshalSteps(pipeline)
+	if err != nil {
+		return nil, err
+	}
+
 	fullySpecified := &FullySpecifiedPipeline{
 		Pipeline:         pipeline,
-		EquivalentValues: []interface{}{pipeline},
+		EquivalentValues: []interface{}{pipelineJSON},
 	}
 	return fullySpecified, nil
 }
@@ -118,9 +139,14 @@ func CreateDukePipeline(name string, description string) (*FullySpecifiedPipelin
 		return nil, err
 	}
 
+	pipelineJSON, err := MarshalSteps(pipeline)
+	if err != nil {
+		return nil, err
+	}
+
 	fullySpecified := &FullySpecifiedPipeline{
 		Pipeline:         pipeline,
-		EquivalentValues: []interface{}{pipeline},
+		EquivalentValues: []interface{}{pipelineJSON},
 	}
 	return fullySpecified, nil
 }
@@ -147,9 +173,14 @@ func CreateSimonPipeline(name string, description string) (*FullySpecifiedPipeli
 		return nil, err
 	}
 
+	pipelineJSON, err := MarshalSteps(pipeline)
+	if err != nil {
+		return nil, err
+	}
+
 	fullySpecified := &FullySpecifiedPipeline{
 		Pipeline:         pipeline,
-		EquivalentValues: []interface{}{pipeline},
+		EquivalentValues: []interface{}{pipelineJSON},
 	}
 	return fullySpecified, nil
 }
@@ -174,9 +205,14 @@ func CreateDataCleaningPipeline(name string, description string) (*FullySpecifie
 		return nil, err
 	}
 
+	pipelineJSON, err := MarshalSteps(pipeline)
+	if err != nil {
+		return nil, err
+	}
+
 	fullySpecified := &FullySpecifiedPipeline{
 		Pipeline:         pipeline,
-		EquivalentValues: []interface{}{pipeline},
+		EquivalentValues: []interface{}{pipelineJSON},
 	}
 	return fullySpecified, nil
 }
@@ -196,9 +232,14 @@ func CreateGroupingFieldComposePipeline(name string, description string, colIndi
 		return nil, err
 	}
 
+	pipelineJSON, err := MarshalSteps(pipeline)
+	if err != nil {
+		return nil, err
+	}
+
 	fullySpecified := &FullySpecifiedPipeline{
 		Pipeline:         pipeline,
-		EquivalentValues: []interface{}{pipeline},
+		EquivalentValues: []interface{}{pipelineJSON},
 	}
 	return fullySpecified, nil
 }
@@ -218,9 +259,14 @@ func CreatePCAFeaturesPipeline(name string, description string) (*FullySpecified
 		return nil, err
 	}
 
+	pipelineJSON, err := MarshalSteps(pipeline)
+	if err != nil {
+		return nil, err
+	}
+
 	fullySpecified := &FullySpecifiedPipeline{
 		Pipeline:         pipeline,
-		EquivalentValues: []interface{}{pipeline},
+		EquivalentValues: []interface{}{pipelineJSON},
 	}
 	return fullySpecified, nil
 }
@@ -240,9 +286,14 @@ func CreateDenormalizePipeline(name string, description string) (*FullySpecified
 		return nil, err
 	}
 
+	pipelineJSON, err := MarshalSteps(pipeline)
+	if err != nil {
+		return nil, err
+	}
+
 	fullySpecified := &FullySpecifiedPipeline{
 		Pipeline:         pipeline,
-		EquivalentValues: []interface{}{pipeline},
+		EquivalentValues: []interface{}{pipelineJSON},
 	}
 	return fullySpecified, nil
 }
@@ -321,9 +372,14 @@ func CreateGoatForwardPipeline(name string, description string, placeCol *model.
 		return nil, err
 	}
 
+	pipelineJSON, err := MarshalSteps(pipeline)
+	if err != nil {
+		return nil, err
+	}
+
 	fullySpecified := &FullySpecifiedPipeline{
 		Pipeline:         pipeline,
-		EquivalentValues: []interface{}{pipeline},
+		EquivalentValues: []interface{}{pipelineJSON},
 	}
 	return fullySpecified, nil
 }
@@ -344,9 +400,14 @@ func CreateGoatReversePipeline(name string, description string, lonSource *model
 		return nil, err
 	}
 
+	pipelineJSON, err := MarshalSteps(pipeline)
+	if err != nil {
+		return nil, err
+	}
+
 	fullySpecified := &FullySpecifiedPipeline{
 		Pipeline:         pipeline,
-		EquivalentValues: []interface{}{pipeline},
+		EquivalentValues: []interface{}{pipelineJSON},
 	}
 	return fullySpecified, nil
 }
@@ -392,9 +453,14 @@ func CreateJoinPipeline(name string, description string, leftJoinCol *model.Vari
 		return nil, err
 	}
 
+	pipelineJSON, err := MarshalSteps(pipeline)
+	if err != nil {
+		return nil, err
+	}
+
 	fullySpecified := &FullySpecifiedPipeline{
 		Pipeline:         pipeline,
-		EquivalentValues: []interface{}{pipeline},
+		EquivalentValues: []interface{}{pipelineJSON},
 	}
 	return fullySpecified, nil
 }
@@ -421,9 +487,14 @@ func CreateDSBoxJoinPipeline(name string, description string, leftJoinCols []str
 		return nil, err
 	}
 
+	pipelineJSON, err := MarshalSteps(pipeline)
+	if err != nil {
+		return nil, err
+	}
+
 	fullySpecified := &FullySpecifiedPipeline{
 		Pipeline:         pipeline,
-		EquivalentValues: []interface{}{pipeline},
+		EquivalentValues: []interface{}{pipelineJSON},
 	}
 	return fullySpecified, nil
 }
@@ -444,9 +515,14 @@ func CreateTimeseriesFormatterPipeline(name string, description string, resource
 		return nil, err
 	}
 
+	pipelineJSON, err := MarshalSteps(pipeline)
+	if err != nil {
+		return nil, err
+	}
+
 	fullySpecified := &FullySpecifiedPipeline{
 		Pipeline:         pipeline,
-		EquivalentValues: []interface{}{pipeline},
+		EquivalentValues: []interface{}{pipelineJSON},
 	}
 	return fullySpecified, nil
 }
@@ -466,9 +542,14 @@ func CreateDatamartDownloadPipeline(name string, description string, searchResul
 		return nil, err
 	}
 
+	pipelineJSON, err := MarshalSteps(pipeline)
+	if err != nil {
+		return nil, err
+	}
+
 	fullySpecified := &FullySpecifiedPipeline{
 		Pipeline:         pipeline,
-		EquivalentValues: []interface{}{pipeline},
+		EquivalentValues: []interface{}{pipelineJSON},
 	}
 	return fullySpecified, nil
 }
@@ -488,9 +569,14 @@ func CreateDatamartAugmentPipeline(name string, description string, searchResult
 		return nil, err
 	}
 
+	pipelineJSON, err := MarshalSteps(pipeline)
+	if err != nil {
+		return nil, err
+	}
+
 	fullySpecified := &FullySpecifiedPipeline{
 		Pipeline:         pipeline,
-		EquivalentValues: []interface{}{pipeline},
+		EquivalentValues: []interface{}{pipelineJSON},
 	}
 	return fullySpecified, nil
 }

--- a/primitive/compute/description/fully_specified.go
+++ b/primitive/compute/description/fully_specified.go
@@ -24,9 +24,14 @@ import (
 	"github.com/uncharted-distil/distil-compute/primitive/compute"
 )
 
+type FullySpecifiedPipeline struct {
+	Pipeline         *pipeline.PipelineDescription
+	EquivalentValues []interface{}
+}
+
 // CreateImageClusteringPipeline creates a fully specified pipeline that will
 // cluster images together, adding a column with the resulting cluster.
-func CreateImageClusteringPipeline(name string, description string, imageVariables []*model.Variable) (*pipeline.PipelineDescription, error) {
+func CreateImageClusteringPipeline(name string, description string, imageVariables []*model.Variable) (*FullySpecifiedPipeline, error) {
 	inputs := []string{"inputs"}
 	outputs := []DataRef{&StepDataRef{5, "produce"}}
 
@@ -48,12 +53,17 @@ func CreateImageClusteringPipeline(name string, description string, imageVariabl
 	if err != nil {
 		return nil, err
 	}
-	return pipeline, nil
+
+	fullySpecified := &FullySpecifiedPipeline{
+		Pipeline:         pipeline,
+		EquivalentValues: []interface{}{pipeline},
+	}
+	return fullySpecified, nil
 }
 
 // CreateSlothPipeline creates a pipeline to peform timeseries clustering on a dataset.
 func CreateSlothPipeline(name string, description string, timeColumn string, valueColumn string,
-	timeSeriesFeatures []*model.Variable) (*pipeline.PipelineDescription, error) {
+	timeSeriesFeatures []*model.Variable) (*FullySpecifiedPipeline, error) {
 
 	steps := make([]Step, 0)
 	steps = append(steps, NewTimeseriesFormatterStep(map[string]DataRef{"inputs": &PipelineDataRef{0}}, []string{"produce"}, compute.DefaultResourceID, -1))
@@ -83,11 +93,16 @@ func CreateSlothPipeline(name string, description string, timeColumn string, val
 	if err != nil {
 		return nil, err
 	}
-	return pipeline, nil
+
+	fullySpecified := &FullySpecifiedPipeline{
+		Pipeline:         pipeline,
+		EquivalentValues: []interface{}{pipeline},
+	}
+	return fullySpecified, nil
 }
 
 // CreateDukePipeline creates a pipeline to peform image featurization on a dataset.
-func CreateDukePipeline(name string, description string) (*pipeline.PipelineDescription, error) {
+func CreateDukePipeline(name string, description string) (*FullySpecifiedPipeline, error) {
 	inputs := []string{"inputs"}
 	outputs := []DataRef{&StepDataRef{1, "produce"}}
 
@@ -100,12 +115,17 @@ func CreateDukePipeline(name string, description string) (*pipeline.PipelineDesc
 	if err != nil {
 		return nil, err
 	}
-	return pipeline, nil
+
+	fullySpecified := &FullySpecifiedPipeline{
+		Pipeline:         pipeline,
+		EquivalentValues: []interface{}{pipeline},
+	}
+	return fullySpecified, nil
 }
 
 // CreateSimonPipeline creates a pipeline to run semantic type inference on a dataset's
 // columns.
-func CreateSimonPipeline(name string, description string) (*pipeline.PipelineDescription, error) {
+func CreateSimonPipeline(name string, description string) (*FullySpecifiedPipeline, error) {
 	inputs := []string{"inputs"}
 	outputs := []DataRef{&StepDataRef{1, "produce_metafeatures"}}
 
@@ -124,11 +144,16 @@ func CreateSimonPipeline(name string, description string) (*pipeline.PipelineDes
 	if err != nil {
 		return nil, err
 	}
-	return pipeline, nil
+
+	fullySpecified := &FullySpecifiedPipeline{
+		Pipeline:         pipeline,
+		EquivalentValues: []interface{}{pipeline},
+	}
+	return fullySpecified, nil
 }
 
 // CreateDataCleaningPipeline creates a pipeline to run data cleaning on a dataset.
-func CreateDataCleaningPipeline(name string, description string) (*pipeline.PipelineDescription, error) {
+func CreateDataCleaningPipeline(name string, description string) (*FullySpecifiedPipeline, error) {
 	inputs := []string{"inputs"}
 	outputs := []DataRef{&StepDataRef{2, "produce"}}
 
@@ -146,11 +171,16 @@ func CreateDataCleaningPipeline(name string, description string) (*pipeline.Pipe
 	if err != nil {
 		return nil, err
 	}
-	return pipeline, nil
+
+	fullySpecified := &FullySpecifiedPipeline{
+		Pipeline:         pipeline,
+		EquivalentValues: []interface{}{pipeline},
+	}
+	return fullySpecified, nil
 }
 
 // CreateGroupingFieldComposePipeline creates a pipeline to create a grouping key field for a dataset.
-func CreateGroupingFieldComposePipeline(name string, description string, colIndices []int, joinChar string, outputName string) (*pipeline.PipelineDescription, error) {
+func CreateGroupingFieldComposePipeline(name string, description string, colIndices []int, joinChar string, outputName string) (*FullySpecifiedPipeline, error) {
 	inputs := []string{"inputs"}
 	outputs := []DataRef{&StepDataRef{1, "produce"}}
 
@@ -163,11 +193,16 @@ func CreateGroupingFieldComposePipeline(name string, description string, colIndi
 	if err != nil {
 		return nil, err
 	}
-	return pipeline, nil
+
+	fullySpecified := &FullySpecifiedPipeline{
+		Pipeline:         pipeline,
+		EquivalentValues: []interface{}{pipeline},
+	}
+	return fullySpecified, nil
 }
 
 // CreatePCAFeaturesPipeline creates a pipeline to run feature ranking on an input dataset.
-func CreatePCAFeaturesPipeline(name string, description string) (*pipeline.PipelineDescription, error) {
+func CreatePCAFeaturesPipeline(name string, description string) (*FullySpecifiedPipeline, error) {
 	inputs := []string{"inputs"}
 	outputs := []DataRef{&StepDataRef{1, "produce_metafeatures"}}
 
@@ -180,11 +215,16 @@ func CreatePCAFeaturesPipeline(name string, description string) (*pipeline.Pipel
 	if err != nil {
 		return nil, err
 	}
-	return pipeline, nil
+
+	fullySpecified := &FullySpecifiedPipeline{
+		Pipeline:         pipeline,
+		EquivalentValues: []interface{}{pipeline},
+	}
+	return fullySpecified, nil
 }
 
 // CreateDenormalizePipeline creates a pipeline to run the denormalize primitive on an input dataset.
-func CreateDenormalizePipeline(name string, description string) (*pipeline.PipelineDescription, error) {
+func CreateDenormalizePipeline(name string, description string) (*FullySpecifiedPipeline, error) {
 	inputs := []string{"inputs"}
 	outputs := []DataRef{&StepDataRef{1, "produce"}}
 
@@ -197,11 +237,16 @@ func CreateDenormalizePipeline(name string, description string) (*pipeline.Pipel
 	if err != nil {
 		return nil, err
 	}
-	return pipeline, nil
+
+	fullySpecified := &FullySpecifiedPipeline{
+		Pipeline:         pipeline,
+		EquivalentValues: []interface{}{pipeline},
+	}
+	return fullySpecified, nil
 }
 
 // CreateTargetRankingPipeline creates a pipeline to run feature ranking on an input dataset.
-func CreateTargetRankingPipeline(name string, description string, target string, features []*model.Variable) (*pipeline.PipelineDescription, error) {
+func CreateTargetRankingPipeline(name string, description string, target string, features []*model.Variable) (*FullySpecifiedPipeline, error) {
 
 	// compute index associated with column name
 	targetIdx := -1
@@ -250,11 +295,16 @@ func CreateTargetRankingPipeline(name string, description string, target string,
 	if err != nil {
 		return nil, err
 	}
-	return pipeline, nil
+
+	fullySpecified := &FullySpecifiedPipeline{
+		Pipeline:         pipeline,
+		EquivalentValues: []interface{}{name, target},
+	}
+	return fullySpecified, nil
 }
 
 // CreateGoatForwardPipeline creates a forward geocoding pipeline.
-func CreateGoatForwardPipeline(name string, description string, placeCol *model.Variable) (*pipeline.PipelineDescription, error) {
+func CreateGoatForwardPipeline(name string, description string, placeCol *model.Variable) (*FullySpecifiedPipeline, error) {
 	inputs := []string{"inputs"}
 	outputs := []DataRef{&StepDataRef{2, "produce"}}
 
@@ -268,11 +318,16 @@ func CreateGoatForwardPipeline(name string, description string, placeCol *model.
 	if err != nil {
 		return nil, err
 	}
-	return pipeline, nil
+
+	fullySpecified := &FullySpecifiedPipeline{
+		Pipeline:         pipeline,
+		EquivalentValues: []interface{}{pipeline},
+	}
+	return fullySpecified, nil
 }
 
 // CreateGoatReversePipeline creates a forward geocoding pipeline.
-func CreateGoatReversePipeline(name string, description string, lonSource *model.Variable, latSource *model.Variable) (*pipeline.PipelineDescription, error) {
+func CreateGoatReversePipeline(name string, description string, lonSource *model.Variable, latSource *model.Variable) (*FullySpecifiedPipeline, error) {
 	inputs := []string{"inputs"}
 	outputs := []DataRef{&StepDataRef{2, "produce"}}
 
@@ -286,12 +341,17 @@ func CreateGoatReversePipeline(name string, description string, lonSource *model
 	if err != nil {
 		return nil, err
 	}
-	return pipeline, nil
+
+	fullySpecified := &FullySpecifiedPipeline{
+		Pipeline:         pipeline,
+		EquivalentValues: []interface{}{pipeline},
+	}
+	return fullySpecified, nil
 }
 
 // CreateJoinPipeline creates a pipeline that joins two input datasets using a caller supplied column.
 // Accuracy is a normalized value that controls how exact the join has to be.
-func CreateJoinPipeline(name string, description string, leftJoinCol *model.Variable, rightJoinCol *model.Variable, accuracy float32) (*pipeline.PipelineDescription, error) {
+func CreateJoinPipeline(name string, description string, leftJoinCol *model.Variable, rightJoinCol *model.Variable, accuracy float32) (*FullySpecifiedPipeline, error) {
 	steps := make([]Step, 0)
 	steps = append(steps, NewDenormalizeStep(map[string]DataRef{"inputs": &PipelineDataRef{0}}, []string{"produce"}))
 	steps = append(steps, NewDenormalizeStep(map[string]DataRef{"inputs": &PipelineDataRef{1}}, []string{"produce"}))
@@ -329,12 +389,17 @@ func CreateJoinPipeline(name string, description string, leftJoinCol *model.Vari
 	if err != nil {
 		return nil, err
 	}
-	return pipeline, nil
+
+	fullySpecified := &FullySpecifiedPipeline{
+		Pipeline:         pipeline,
+		EquivalentValues: []interface{}{pipeline},
+	}
+	return fullySpecified, nil
 }
 
 // CreateDSBoxJoinPipeline creates a pipeline that joins two input datasets
 // using caller supplied columns.
-func CreateDSBoxJoinPipeline(name string, description string, leftJoinCols []string, rightJoinCols []string, accuracy float32) (*pipeline.PipelineDescription, error) {
+func CreateDSBoxJoinPipeline(name string, description string, leftJoinCols []string, rightJoinCols []string, accuracy float32) (*FullySpecifiedPipeline, error) {
 	inputs := []string{"inputs"}
 	outputs := []DataRef{&StepDataRef{2, "produce"}}
 
@@ -353,11 +418,16 @@ func CreateDSBoxJoinPipeline(name string, description string, leftJoinCols []str
 	if err != nil {
 		return nil, err
 	}
-	return pipeline, nil
+
+	fullySpecified := &FullySpecifiedPipeline{
+		Pipeline:         pipeline,
+		EquivalentValues: []interface{}{pipeline},
+	}
+	return fullySpecified, nil
 }
 
 // CreateTimeseriesFormatterPipeline creates a time series formatter pipeline.
-func CreateTimeseriesFormatterPipeline(name string, description string, resource string) (*pipeline.PipelineDescription, error) {
+func CreateTimeseriesFormatterPipeline(name string, description string, resource string) (*FullySpecifiedPipeline, error) {
 
 	inputs := []string{"inputs"}
 	outputs := []DataRef{&StepDataRef{1, "produce"}}
@@ -371,11 +441,16 @@ func CreateTimeseriesFormatterPipeline(name string, description string, resource
 	if err != nil {
 		return nil, err
 	}
-	return pipeline, nil
+
+	fullySpecified := &FullySpecifiedPipeline{
+		Pipeline:         pipeline,
+		EquivalentValues: []interface{}{pipeline},
+	}
+	return fullySpecified, nil
 }
 
 // CreateDatamartDownloadPipeline creates a pipeline to download data from a datamart.
-func CreateDatamartDownloadPipeline(name string, description string, searchResult string, systemIdentifier string) (*pipeline.PipelineDescription, error) {
+func CreateDatamartDownloadPipeline(name string, description string, searchResult string, systemIdentifier string) (*FullySpecifiedPipeline, error) {
 	inputs := []string{"inputs"}
 	outputs := []DataRef{&StepDataRef{1, "produce"}}
 
@@ -388,11 +463,16 @@ func CreateDatamartDownloadPipeline(name string, description string, searchResul
 	if err != nil {
 		return nil, err
 	}
-	return pipeline, nil
+
+	fullySpecified := &FullySpecifiedPipeline{
+		Pipeline:         pipeline,
+		EquivalentValues: []interface{}{pipeline},
+	}
+	return fullySpecified, nil
 }
 
 // CreateDatamartAugmentPipeline creates a pipeline to augment data with datamart data.
-func CreateDatamartAugmentPipeline(name string, description string, searchResult string, systemIdentifier string) (*pipeline.PipelineDescription, error) {
+func CreateDatamartAugmentPipeline(name string, description string, searchResult string, systemIdentifier string) (*FullySpecifiedPipeline, error) {
 	inputs := []string{"inputs"}
 	outputs := []DataRef{&StepDataRef{1, "produce"}}
 
@@ -405,5 +485,10 @@ func CreateDatamartAugmentPipeline(name string, description string, searchResult
 	if err != nil {
 		return nil, err
 	}
-	return pipeline, nil
+
+	fullySpecified := &FullySpecifiedPipeline{
+		Pipeline:         pipeline,
+		EquivalentValues: []interface{}{pipeline},
+	}
+	return fullySpecified, nil
 }

--- a/primitive/compute/description/preprocessing_test.go
+++ b/primitive/compute/description/preprocessing_test.go
@@ -410,7 +410,7 @@ func TestCreatePCAFeaturesPipeline(t *testing.T) {
 	pipeline, err := CreatePCAFeaturesPipeline("pca_features_test", "test pca feature ranking pipeline")
 	assert.NoError(t, err)
 
-	data, err := proto.Marshal(pipeline)
+	data, err := proto.Marshal(pipeline.Pipeline)
 	assert.NoError(t, err)
 	assert.NotNil(t, data)
 
@@ -422,7 +422,7 @@ func TestCreateSimonPipeline(t *testing.T) {
 	pipeline, err := CreateSimonPipeline("simon_test", "test simon classification pipeline")
 	assert.NoError(t, err)
 
-	data, err := proto.Marshal(pipeline)
+	data, err := proto.Marshal(pipeline.Pipeline)
 	assert.NoError(t, err)
 	assert.NotNil(t, data)
 
@@ -434,7 +434,7 @@ func TestCreateDataCleaningPipeline(t *testing.T) {
 	pipeline, err := CreateDataCleaningPipeline("data cleaning test", "test data cleaning pipeline")
 	assert.NoError(t, err)
 
-	data, err := proto.Marshal(pipeline)
+	data, err := proto.Marshal(pipeline.Pipeline)
 	assert.NoError(t, err)
 	assert.NotNil(t, data)
 
@@ -451,7 +451,7 @@ func TestCreateSlothPipeline(t *testing.T) {
 	pipeline, err := CreateSlothPipeline("sloth_test", "test sloth object detection pipeline", "time", "value", timeSeriesVariables)
 	assert.NoError(t, err)
 
-	data, err := proto.Marshal(pipeline)
+	data, err := proto.Marshal(pipeline.Pipeline)
 	assert.NoError(t, err)
 	assert.NotNil(t, data)
 
@@ -463,7 +463,7 @@ func TestCreateDukePipeline(t *testing.T) {
 	pipeline, err := CreateDukePipeline("duke_test", "test duke data summary pipeline")
 	assert.NoError(t, err)
 
-	data, err := proto.Marshal(pipeline)
+	data, err := proto.Marshal(pipeline.Pipeline)
 	assert.NoError(t, err)
 	assert.NotNil(t, data)
 
@@ -483,7 +483,7 @@ func TestCreateTargetRankingPipeline(t *testing.T) {
 	pipeline, err := CreateTargetRankingPipeline("target_ranking_test", "test target_ranking pipeline", "hall_of_fame", vars)
 	assert.NoError(t, err)
 
-	data, err := proto.Marshal(pipeline)
+	data, err := proto.Marshal(pipeline.Pipeline)
 	assert.NoError(t, err)
 	assert.NotNil(t, data)
 
@@ -499,7 +499,7 @@ func TestCreateGoatForwardPipeline(t *testing.T) {
 	pipeline, err := CreateGoatForwardPipeline("goat_forward_test", "test goat forward geocoding pipeline", region)
 	assert.NoError(t, err)
 
-	data, err := proto.Marshal(pipeline)
+	data, err := proto.Marshal(pipeline.Pipeline)
 	assert.NoError(t, err)
 	assert.NotNil(t, data)
 
@@ -519,7 +519,7 @@ func TestCreateGoatReversePipeline(t *testing.T) {
 	pipeline, err := CreateGoatReversePipeline("goat_reverse_test", "test goat reverse geocoding pipeline", lat, lon)
 	assert.NoError(t, err)
 
-	data, err := proto.Marshal(pipeline)
+	data, err := proto.Marshal(pipeline.Pipeline)
 	assert.NoError(t, err)
 	assert.NotNil(t, data)
 
@@ -532,7 +532,7 @@ func TestCreateJoinPipeline(t *testing.T) {
 		&model.Variable{DisplayName: "Doubles"}, &model.Variable{DisplayName: "horsepower"}, 0.8)
 	assert.NoError(t, err)
 
-	data, err := proto.Marshal(pipeline)
+	data, err := proto.Marshal(pipeline.Pipeline)
 	assert.NoError(t, err)
 	assert.NotNil(t, data)
 
@@ -544,7 +544,7 @@ func TestCreateDSBoxJoinPipeline(t *testing.T) {
 	pipeline, err := CreateDSBoxJoinPipeline("ds_join_test", "test ds box join pipeline", []string{"Doubles"}, []string{"horsepower"}, 0.8)
 	assert.NoError(t, err)
 
-	data, err := proto.Marshal(pipeline)
+	data, err := proto.Marshal(pipeline.Pipeline)
 	assert.NoError(t, err)
 	assert.NotNil(t, data)
 
@@ -556,7 +556,7 @@ func TestCreateDenormalizePipeline(t *testing.T) {
 	pipeline, err := CreateDenormalizePipeline("denorm_test", "test denorm pipeline")
 	assert.NoError(t, err)
 
-	data, err := proto.Marshal(pipeline)
+	data, err := proto.Marshal(pipeline.Pipeline)
 	assert.NoError(t, err)
 	assert.NotNil(t, data)
 
@@ -568,7 +568,7 @@ func TestCreateTimeseriesFormatterPipeline(t *testing.T) {
 	pipeline, err := CreateTimeseriesFormatterPipeline("formatter_test", "test formatter pipeline", "0")
 	assert.NoError(t, err)
 
-	data, err := proto.Marshal(pipeline)
+	data, err := proto.Marshal(pipeline.Pipeline)
 	assert.NoError(t, err)
 	assert.NotNil(t, data)
 
@@ -580,7 +580,7 @@ func TestCreateDatamartDownloadPipeline(t *testing.T) {
 	pipeline, err := CreateDatamartDownloadPipeline("download_test", "test download pipeline", searchResult, "NYU")
 	assert.NoError(t, err)
 
-	data, err := proto.Marshal(pipeline)
+	data, err := proto.Marshal(pipeline.Pipeline)
 	assert.NoError(t, err)
 	assert.NotNil(t, data)
 
@@ -592,7 +592,7 @@ func TestCreateDatamartAugmentPipeline(t *testing.T) {
 	pipeline, err := CreateDatamartAugmentPipeline("augment_test", "test augment pipeline", searchResult, "NYU")
 	assert.NoError(t, err)
 
-	data, err := proto.Marshal(pipeline)
+	data, err := proto.Marshal(pipeline.Pipeline)
 	assert.NoError(t, err)
 	assert.NotNil(t, data)
 


### PR DESCRIPTION
Wrap fully specified pipelines into a structure which can be used to specify equivalent pipelines (for example MI ranking is not the complete pipeline equivalency).