### PR TITLE
Timeseries Parameters

### DIFF
--- a/primitive/compute/description/preprocessing.go
+++ b/primitive/compute/description/preprocessing.go
@@ -62,6 +62,7 @@ func CreateUserDatasetPipeline(name string, description string, datasetDescripti
 	isTimeseries := false
 	groupingIndices := make([]int, 0)
 	timeseriesGrouping := getTimeseriesGrouping(datasetDescription)
+	targetName := datasetDescription.TargetFeature.Name
 	if timeseriesGrouping != nil {
 		isTimeseries = true
 		groupingSet := map[string]bool{}
@@ -75,6 +76,7 @@ func CreateUserDatasetPipeline(name string, description string, datasetDescripti
 		groupingIndices = listColumns(datasetDescription.AllFeatures, groupingSet)
 		selectedSet[strings.ToLower(timeseriesGrouping.XCol)] = true
 		selectedSet[strings.ToLower(timeseriesGrouping.YCol)] = true
+		targetName = timeseriesGrouping.YCol
 	}
 
 	// augment the dataset if needed
@@ -125,7 +127,7 @@ func CreateUserDatasetPipeline(name string, description string, datasetDescripti
 	}
 
 	// create the semantic type update primitive
-	updateSemanticTypes, err := createUpdateSemanticTypes(datasetDescription.TargetFeature.Name, datasetDescription.AllFeatures, selectedSet, offset)
+	updateSemanticTypes, err := createUpdateSemanticTypes(targetName, datasetDescription.AllFeatures, selectedSet, offset)
 	if err != nil {
 		return nil, err
 	}

--- a/primitive/compute/description/primitive_steps.go
+++ b/primitive/compute/description/primitive_steps.go
@@ -87,12 +87,6 @@ func NewKMeansCluteringStep(inputs map[string]DataRef, outputMethods []string) *
 
 // NewSlothStep creates a Sloth timeseries clustering step.
 func NewSlothStep(inputs map[string]DataRef, outputMethods []string) *StepData {
-	// since Sloth has fit & produce, need to set the params from
-	// set_training_data. In this case, outputs is not used.
-	if inputs["inputs"] != nil && inputs["outputs"] == nil {
-		inputs["outputs"] = inputs["inputs"]
-	}
-
 	return NewStepData(
 		&pipeline.Primitive{
 			Id:         "77bf4b92-2faa-3e38-bb7e-804131243a7f",


### PR DESCRIPTION
Removed the output param from the sloth step creation.

Timeseries prepend no longer sets the target as parameter. That was happening because the wrong column was being used for target name. It was using the grouping column rather than the underlying target column.