### PR TITLE
Timeseries Prepend & Clustering

### DIFF
--- a/metadata/verification.go
+++ b/metadata/verification.go
@@ -82,7 +82,10 @@ func VerifyAndUpdate(m *model.Metadata, dataPath string, source DatasetSource) (
 	// is no original schema that were comparing to
 	if source == Augmented {
 		for _, v := range m.DataResources[0].Variables {
-			v.OriginalType = v.Type
+			if v.Type != v.OriginalType {
+				v.OriginalType = v.Type
+				updated = true
+			}
 		}
 	}
 

--- a/model/schema_types.go
+++ b/model/schema_types.go
@@ -167,6 +167,8 @@ const (
 	TA2TargetType = "https://metadata.datadrivendiscovery.org/types/Target"
 	// TA2GroupingKeyType is the semantic type indicating a grouping key
 	TA2GroupingKeyType = "https://metadata.datadrivendiscovery.org/types/GroupingKey"
+	// TA2SuggestedGroupingType is the semantic type indicating a suggested grouping key
+	TA2SuggestedGroupingType = "https://metadata.datadrivendiscovery.org/types/SuggestedGroupingKey"
 
 	// Lincoln Labs D3M Dataset Type Keys - these are the types used in the D3M dataset format.
 	// These should not be used/stored internally, but instead translated into the Distil

--- a/primitive/compute/description/preprocessing.go
+++ b/primitive/compute/description/preprocessing.go
@@ -206,7 +206,15 @@ func generatePrependSteps(datasetDescription *UserDatasetDescription,
 		})
 		steps = append(steps, addTime)
 		steps = append(steps, NewDatasetWrapperStep(map[string]DataRef{"inputs": &StepDataRef{offset + 4, "produce"}}, []string{"produce"}, offset+5, ""))
-		offset += 7
+
+		// add the suggested grouping key type to the id columns
+		addGroupingKey := NewAddSemanticTypeStep(nil, nil, &ColumnUpdate{
+			SemanticTypes: []string{model.TA2SuggestedGroupingType},
+			Indices:       groupingIndices,
+		})
+		steps = append(steps, addGroupingKey)
+		steps = append(steps, NewDatasetWrapperStep(map[string]DataRef{"inputs": &StepDataRef{offset + 6, "produce"}}, []string{"produce"}, offset+7, ""))
+		offset += 9
 	} else {
 		steps = append(steps, NewDenormalizeStep(map[string]DataRef{"inputs": dataRef}, []string{"produce"}))
 		steps = append(steps, NewColumnParserStep(nil, nil, []string{model.TA2IntegerType, model.TA2BooleanType, model.TA2RealType}))

--- a/primitive/compute/description/preprocessing_test.go
+++ b/primitive/compute/description/preprocessing_test.go
@@ -448,7 +448,7 @@ func TestCreateSlothPipeline(t *testing.T) {
 		{Name: "value", Type: "string", OriginalType: "unknown", Index: 1},
 	}
 
-	pipeline, err := CreateSlothPipeline("sloth_test", "test sloth object detection pipeline", "time", "value", timeSeriesVariables)
+	pipeline, err := CreateSlothPipeline("sloth_test", "test sloth object detection pipeline", "time", "value", nil, timeSeriesVariables)
 	assert.NoError(t, err)
 
 	data, err := proto.Marshal(pipeline.Pipeline)


### PR DESCRIPTION
Timeseries imported will not have the suggested grouping key role so additional semantic types need to be added to the pipeline to make sure the grouping compose and VAR primitives run properly.