### PR TITLE
Removes unnecessary concat after remote sensing featurizer

### DIFF
--- a/primitive/compute/description/cluster.go
+++ b/primitive/compute/description/cluster.go
@@ -544,7 +544,7 @@ func NewSatelliteImageLoaderStep(inputs map[string]DataRef, outputMethods []stri
 			Digest:     "cf44b2f5af90f10ef9935496655a202bfc8a4a0fa24b8e9d733ee61f096bda87",
 		},
 		outputMethods,
-		map[string]interface{}{"return_result": "replace"},
+		map[string]interface{}{"return_result": "replace", "compress_data": true},
 		inputs,
 	)
 }
@@ -560,7 +560,7 @@ func NewRemoteSensingPretrainedStep(inputs map[string]DataRef, outputMethods []s
 			Digest:     "cf44b2f5af90f10ef9935496655a202bfc8a4a0fa24b8e9d733ee61f096bda87",
 		},
 		outputMethods,
-		map[string]interface{}{"batch_size": 32},
+		map[string]interface{}{"batch_size": 32, "decompress_data": true},
 		inputs,
 	)
 }

--- a/primitive/compute/description/fully_specified.go
+++ b/primitive/compute/description/fully_specified.go
@@ -84,12 +84,6 @@ func CreateMultiBandImageFeaturizationPipeline(name string, description string, 
 	offset++
 
 	steps = append(steps, NewRemoteSensingPretrainedStep(map[string]DataRef{"inputs": &StepDataRef{offset, "produce"}}, []string{"produce"}))
-	offset++
-
-	steps = append(steps, NewRemoveColumnsStep(map[string]DataRef{"inputs": &StepDataRef{offset - 1, "produce"}}, []string{"produce"}, []int{imageCol.Index}))
-	offset++
-
-	steps = append(steps, NewHorizontalConcatStep(map[string]DataRef{"left": &StepDataRef{offset, "produce"}, "right": &StepDataRef{offset - 1, "produce"}}, []string{"produce"}, true, true))
 
 	inputs := []string{"inputs"}
 	outputs := []DataRef{&StepDataRef{len(steps) - 1, "produce"}}


### PR DESCRIPTION
1. The remote sensing featurizer has been updated so that it replaces the image column with feature columns, and leaves the other columns in place.  This removes the need for a horizontal concat in the pre-featurizer pipeline.
2. Updates relevant primitives in pre-featurizing pipeline to use compression