### PR TITLE
Cluster on float values for remote sensing

### DIFF
--- a/primitive/compute/description/cluster.go
+++ b/primitive/compute/description/cluster.go
@@ -271,8 +271,14 @@ func CreatePreFeaturizedMultiBandImageClusteringPipeline(name string, descriptio
 		steps = []Step{
 			NewDatasetToDataframeStep(map[string]DataRef{"inputs": &PipelineDataRef{0}}, []string{"produce"}),
 			NewDistilColumnParserStep(map[string]DataRef{"inputs": &StepDataRef{0, "produce"}}, []string{"produce"}, []string{model.TA2RealType}),
-			NewKMeansClusteringStep(map[string]DataRef{"inputs": &StepDataRef{1, "produce"}}, []string{"produce"}),
-			NewConstructPredictionStep(map[string]DataRef{"inputs": &StepDataRef{2, "produce"}}, []string{"produce"}, &StepDataRef{1, "produce"}),
+			NewExtractColumnsByStructuralTypeStep(map[string]DataRef{"inputs": &StepDataRef{1, "produce"}}, []string{"produce"},
+				[]string{
+					"float",         // python type
+					"numpy.float32", // numpy types
+					"numpy.float64",
+				}),
+			NewKMeansClusteringStep(map[string]DataRef{"inputs": &StepDataRef{2, "produce"}}, []string{"produce"}),
+			NewConstructPredictionStep(map[string]DataRef{"inputs": &StepDataRef{3, "produce"}}, []string{"produce"}, &StepDataRef{1, "produce"}),
 		}
 	} else {
 		steps = []Step{


### PR DESCRIPTION
D3M index is currently being included in the clustering step when working with pre-featurized remote sensing datasets because it is typed as an integer.  We extract only floats to and cluster on those instead.