### PR TITLE
Fit results support

### DIFF
--- a/primitive/compute/client.go
+++ b/primitive/compute/client.go
@@ -316,13 +316,8 @@ func (c *Client) GenerateSolutionScores(ctx context.Context, solutionID string, 
 }
 
 // GenerateSolutionFit generates fit for candidate solutions.
-func (c *Client) GenerateSolutionFit(ctx context.Context, solutionID string, datasetURIs []string) ([]*pipeline.GetFitSolutionResultsResponse, error) {
-	fitSolutionRequest := &pipeline.FitSolutionRequest{
-		SolutionId: solutionID,
-		Inputs:     createInputValues(datasetURIs),
-	}
-
-	fitSolutionResponse, err := c.client.FitSolution(ctx, fitSolutionRequest)
+func (c *Client) GenerateSolutionFit(ctx context.Context, request *pipeline.FitSolutionRequest) ([]*pipeline.GetFitSolutionResultsResponse, error) {
+	fitSolutionResponse, err := c.client.FitSolution(ctx, request)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to start solution fitting")
 	}


### PR DESCRIPTION
Part of fix for uncharted-distil/distil#1913.

1. Adds output support to fit request for execute pipeline calls
2. Removes explicit produce call from pipeline execute, since the fit will generate the results we use
