### PR TITLE
Remote sensing loading and featurization args

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/Jeffail/gabs/v2 v2.2.0
 	github.com/araddon/dateparse v0.0.0-20190622164848-0fb0a474d195
+	github.com/caarlos0/env v3.5.0+incompatible // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang/protobuf v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/Jeffail/gabs/v2 v2.2.0 h1:7touC+WzbQ7LO5+mwgxT44miyTqAVCOlIWLA6PiIB5w
 github.com/Jeffail/gabs/v2 v2.2.0/go.mod h1:xCn81vdHKxFUuWWAaD5jCTQDNPBMh5pPs9IJ+NcziBI=
 github.com/araddon/dateparse v0.0.0-20190622164848-0fb0a474d195 h1:c4mLfegoDw6OhSJXTd2jUEQgZUQuJWtocudb97Qn9EM=
 github.com/araddon/dateparse v0.0.0-20190622164848-0fb0a474d195/go.mod h1:SLqhdZcd+dF3TEVL2RMoob5bBP5R1P1qkox+HtCBgGI=
+github.com/caarlos0/env v3.5.0+incompatible h1:Yy0UN8o9Wtr/jGHZDpCBLpNrzcFLLM2yixi/rBrKyJs=
+github.com/caarlos0/env v3.5.0+incompatible/go.mod h1:tdCsowwCzMLdkqRYDlHpZCp2UooDD3MspDBjZ2AD02Y=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=

--- a/primitive/compute/description/fully_specified.go
+++ b/primitive/compute/description/fully_specified.go
@@ -43,7 +43,9 @@ func MarshalSteps(step *pipeline.PipelineDescription) (string, error) {
 }
 
 // CreateMultiBandImageFeaturizationPipeline creates a pipline that will featurize multiband images.
-func CreateMultiBandImageFeaturizationPipeline(name string, description string, variables []*model.Variable) (*FullySpecifiedPipeline, error) {
+func CreateMultiBandImageFeaturizationPipeline(name string, description string, variables []*model.Variable,
+	numJobs int, batchSize int) (*FullySpecifiedPipeline, error) {
+
 	// add semantic types to variables that are images and group ids
 	var grouping *model.MultiBandImageGrouping
 	variableMap := map[string]*model.Variable{}
@@ -80,10 +82,10 @@ func CreateMultiBandImageFeaturizationPipeline(name string, description string, 
 	steps = append(steps, NewAddSemanticTypeStep(map[string]DataRef{"inputs": &StepDataRef{offset, "produce"}}, []string{"produce"}, addGrouping))
 	offset++
 
-	steps = append(steps, NewSatelliteImageLoaderStep(map[string]DataRef{"inputs": &StepDataRef{offset, "produce"}}, []string{"produce"}))
+	steps = append(steps, NewSatelliteImageLoaderStep(map[string]DataRef{"inputs": &StepDataRef{offset, "produce"}}, []string{"produce"}, numJobs))
 	offset++
 
-	steps = append(steps, NewRemoteSensingPretrainedStep(map[string]DataRef{"inputs": &StepDataRef{offset, "produce"}}, []string{"produce"}))
+	steps = append(steps, NewRemoteSensingPretrainedStep(map[string]DataRef{"inputs": &StepDataRef{offset, "produce"}}, []string{"produce"}, batchSize))
 
 	inputs := []string{"inputs"}
 	outputs := []DataRef{&StepDataRef{len(steps) - 1, "produce"}}


### PR DESCRIPTION
Part of fix for uncharted-distil/distil#2026

Adds args for remote sensing loading and featurization primitives, allowing for GPU batching and the number of parallel jobs to be set by the TA3.  This is necessary to account for execution environment.  The TA2 has similar args it applies to remote sensing related pipelines it creates.