### PR TITLE
Adds geobounds filter support

### DIFF
--- a/primitive/compute/description/preprocessing_test.go
+++ b/primitive/compute/description/preprocessing_test.go
@@ -265,7 +265,7 @@ func TestCreateUserDatasetPipeline(t *testing.T) {
 	assert.Equal(t, "inputs.0", inputs)
 
 	pythonPath = pipeline.GetSteps()[1].GetPrimitive().GetPrimitive().GetPythonPath()
-	assert.Equal(t, "d3m.primitives.data_transformation.column_parser.Common", pythonPath)
+	assert.Equal(t, "d3m.primitives.data_transformation.column_parser.DistilColumnParser", pythonPath)
 
 	pythonPath = pipeline.GetSteps()[2].GetPrimitive().GetPrimitive().GetPythonPath()
 	assert.Equal(t, "d3m.primitives.operator.dataset_map.DataFrameCommon", pythonPath)
@@ -374,7 +374,7 @@ func TestCreateUserDatasetEmpty(t *testing.T) {
 	assert.Equal(t, "inputs.0", inputs)
 
 	pythonPath = pipeline.GetSteps()[1].GetPrimitive().GetPrimitive().GetPythonPath()
-	assert.Equal(t, "d3m.primitives.data_transformation.column_parser.Common", pythonPath)
+	assert.Equal(t, "d3m.primitives.data_transformation.column_parser.DistilColumnParser", pythonPath)
 
 	pythonPath = pipeline.GetSteps()[2].GetPrimitive().GetPrimitive().GetPythonPath()
 	assert.Equal(t, "d3m.primitives.operator.dataset_map.DataFrameCommon", pythonPath)

--- a/primitive/compute/description/primitive_steps.go
+++ b/primitive/compute/description/primitive_steps.go
@@ -648,6 +648,30 @@ func NewDateTimeRangeFilterStep(inputs map[string]DataRef, outputMethods []strin
 	)
 }
 
+// NewVectorBoundsFilterStep creates a primitive that will allow for a vector of values to be filtered included/excluded value range.
+// The input min and max ranges are specified as lists, where the i'th element of the min/max lists are applied to the i'th value of the target vectors
+// as the filter.
+func NewVectorBoundsFilterStep(inputs map[string]DataRef, outputMethods []string, column int, inclusive bool, min []float64, max []float64, strict bool) *StepData {
+	return NewStepData(
+		&pipeline.Primitive{
+			Id:         "c2fa34c0-2d1b-42af-91d2-515da4a27752",
+			Version:    "0.5.1",
+			Name:       "Vector bounds filter",
+			PythonPath: "d3m.primitives.data_transformation.vector_bounds_filter.DistilVectorBoundsFilter",
+			Digest:     "face2225a76870fe1d29ddb83be06f19ecadab52532c0b7ec011f2f469c70321",
+		},
+		outputMethods,
+		map[string]interface{}{
+			"column":    column,
+			"inclusive": inclusive,
+			"mins":      min,
+			"maxs":      max,
+			"strict":    strict,
+		},
+		inputs,
+	)
+}
+
 // NewGoatForwardStep creates a GOAT forward geocoding primitive.  A string column
 // containing a place name or address is passed in, and the primitive will
 // return a DataFrame containing the lat/lon coords of the place.  If location could


### PR DESCRIPTION
Part of fix for uncharted-distil/distil#2051.

Inserts a pair of vector filter primitive steps into the prepend pipeline to enforce user-specified geo coordinate filtering.  The first step filters based on x coords from the bounds array (the even elements), the second filters based on y coords (the odd elements).