### PR TITLE
Create bounds from x, y, width, height

### DIFF
--- a/model/filter.go
+++ b/model/filter.go
@@ -75,6 +75,16 @@ type Bounds struct {
 	MaxY float64 `json:"maxY"`
 }
 
+// NewBounds creates a Bounds struct from an origin point and width and height.
+func NewBounds(minX float64, minY float64, width float64, height float64) *Bounds {
+	return &Bounds{
+		MinX: minX,
+		MinY: minY,
+		MaxX: minX + width,
+		MaxY: minY + height,
+	}
+}
+
 // Filter defines a variable filter.
 type Filter struct {
 	Key        string   `json:"key"`


### PR DESCRIPTION
Adds a convenience function to build create a bounds object from x, y, width and height.
