### PR TITLE
Geobounds Fitler

### DIFF
--- a/primitive/compute/description/preprocessing.go
+++ b/primitive/compute/description/preprocessing.go
@@ -517,8 +517,8 @@ func createFilterData(filters []*model.Filter, columnIndices map[string]int, off
 			maxX := f.Bounds.MaxX
 			minY := f.Bounds.MinY
 			maxY := f.Bounds.MaxY
-			minValues := [][]float64{{minX, minY, minX, minY, minX, minY, minX, minY}}
-			maxValues := [][]float64{{maxX, maxY, maxX, maxY, maxX, maxY, maxX, maxY}}
+			minValues := []float64{minX, minY, minX, minY, minX, minY, minX, minY}
+			maxValues := []float64{maxX, maxY, maxX, maxY, maxX, maxY, maxX, maxY}
 			filter = NewVectorBoundsFilterStep(nil, nil, colIndex, inclusive, minValues, maxValues, false)
 			wrapper := NewDatasetWrapperStep(map[string]DataRef{"inputs": &StepDataRef{offset - 1, "produce"}}, []string{"produce"}, offset, "")
 			filterSteps = append(filterSteps, filter, wrapper)

--- a/primitive/compute/description/preprocessing.go
+++ b/primitive/compute/description/preprocessing.go
@@ -16,7 +16,6 @@
 package description
 
 import (
-	"math"
 	"sort"
 	"strings"
 
@@ -510,30 +509,21 @@ func createFilterData(filters []*model.Filter, columnIndices map[string]int, off
 			offset += 2
 
 		case model.GeoBoundsFilter:
-			// This is a two-step filter, and assumes to be working on a vector that contains 4 points defining a geographic area.  The vector
+			// This is a filter that assumes to be working on a vector that contains 4 points defining a geographic area.  The vector
 			// is defined as [x0, y0, x1, y1, x2, y2, x3, y3], where (x0, y0) is the LL corner of the bounds, and the points are ordered in a
-			// clockwise fashion.  The first filter removes rows with x values outside the bounds, and the 2nd remove rows with y values
-			// outside the desired bounds.
-			inf := math.Inf(1)
-			negInf := math.Inf(-1)
+			// clockwise fashion.
 
 			minX := f.Bounds.MinX
 			maxX := f.Bounds.MaxX
-			minXValues := []float64{minX, negInf, minX, negInf, minX, negInf, minX, negInf}
-			maxXValues := []float64{maxX, inf, maxX, inf, maxX, inf, maxX, inf}
-			filter = NewVectorBoundsFilterStep(nil, nil, colIndex, inclusive, minXValues, maxXValues, false)
+			minY := f.Bounds.MinY
+			maxY := f.Bounds.MaxY
+			minValues := [][]float64{{minX, minY, minX, minY, minX, minY, minX, minY}}
+			maxValues := [][]float64{{maxX, maxY, maxX, maxY, maxX, maxY, maxX, maxY}}
+			filter = NewVectorBoundsFilterStep(nil, nil, colIndex, inclusive, minValues, maxValues, false)
 			wrapper := NewDatasetWrapperStep(map[string]DataRef{"inputs": &StepDataRef{offset - 1, "produce"}}, []string{"produce"}, offset, "")
 			filterSteps = append(filterSteps, filter, wrapper)
 
-			minY := f.Bounds.MinY
-			maxY := f.Bounds.MaxY
-			minYValues := []float64{negInf, minY, negInf, minY, negInf, minY, negInf, minY}
-			maxYValues := []float64{inf, maxY, inf, maxY, inf, maxY, inf, maxY, inf, maxY}
-			filter = NewVectorBoundsFilterStep(nil, nil, colIndex, inclusive, minYValues, maxYValues, false)
-			wrapper = NewDatasetWrapperStep(map[string]DataRef{"inputs": &StepDataRef{offset - 1, "produce"}}, []string{"produce"}, offset, "")
-			filterSteps = append(filterSteps, filter, wrapper)
-
-			offset += 4
+			offset += 2
 		}
 
 	}

--- a/primitive/compute/description/primitive_steps.go
+++ b/primitive/compute/description/primitive_steps.go
@@ -651,7 +651,7 @@ func NewDateTimeRangeFilterStep(inputs map[string]DataRef, outputMethods []strin
 // NewVectorBoundsFilterStep creates a primitive that will allow for a vector of values to be filtered included/excluded value range.
 // The input min and max ranges are specified as lists, where the i'th element of the min/max lists are applied to the i'th value of the target vectors
 // as the filter.
-func NewVectorBoundsFilterStep(inputs map[string]DataRef, outputMethods []string, column int, inclusive bool, min [][]float64, max [][]float64, strict bool) *StepData {
+func NewVectorBoundsFilterStep(inputs map[string]DataRef, outputMethods []string, column int, inclusive bool, min []float64, max []float64, strict bool) *StepData {
 	return NewStepData(
 		&pipeline.Primitive{
 			Id:         "c2fa34c0-2d1b-42af-91d2-515da4a27752",

--- a/primitive/compute/description/primitive_steps.go
+++ b/primitive/compute/description/primitive_steps.go
@@ -651,7 +651,7 @@ func NewDateTimeRangeFilterStep(inputs map[string]DataRef, outputMethods []strin
 // NewVectorBoundsFilterStep creates a primitive that will allow for a vector of values to be filtered included/excluded value range.
 // The input min and max ranges are specified as lists, where the i'th element of the min/max lists are applied to the i'th value of the target vectors
 // as the filter.
-func NewVectorBoundsFilterStep(inputs map[string]DataRef, outputMethods []string, column int, inclusive bool, min []float64, max []float64, strict bool) *StepData {
+func NewVectorBoundsFilterStep(inputs map[string]DataRef, outputMethods []string, column int, inclusive bool, min [][]float64, max [][]float64, strict bool) *StepData {
 	return NewStepData(
 		&pipeline.Primitive{
 			Id:         "c2fa34c0-2d1b-42af-91d2-515da4a27752",


### PR DESCRIPTION
Geobounds filtering is now reduced to a single step of the vector filter. The vector filter minimums and maximums parameters were changed to lists of lists to match the expected format.

Note that the API as used in Auto ML does not support the parsing of nested list hyper params. To test it properly, I had to modify the api utils file, which gets overwritten on api version updates. We should probably redesign the vector bounds filter primitive to be simpler and unnest the lists.

Note also that the current version of the primitive does not treat exclusive filters as being the complement (inverse) of inclusive filters. It currently considers an exclusive filter as being the rows that have every point outside of the range [min, max].