### PR TITLE
remove variables that can't be ranked from mi ranking pipeline

### DIFF
--- a/primitive/compute/description/preprocessing_test.go
+++ b/primitive/compute/description/preprocessing_test.go
@@ -480,7 +480,7 @@ func TestCreateTargetRankingPipeline(t *testing.T) {
 			OriginalType: model.CategoricalType,
 		},
 	}
-	pipeline, err := CreateTargetRankingPipeline("target_ranking_test", "test target_ranking pipeline", "hall_of_fame", vars)
+	pipeline, err := CreateTargetRankingPipeline("target_ranking_test", "test target_ranking pipeline", vars[0], vars, map[string]bool{"hall_of_fame": true})
 	assert.NoError(t, err)
 
 	data, err := proto.Marshal(pipeline.Pipeline)


### PR DESCRIPTION
part of fix for uncharted-distil/distil#2262

Removes variables that should not / can not be ranked from pipeline - previously they were left in and the downstream ta2 primitive would rank some fields that were not exposed to the user through the UI.