### PR TITLE
Fix filtering issue of Distil Roles

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -587,6 +587,13 @@ func IsTA2Field(distilRole string, selectedRole string) bool {
 	return false
 }
 
+// DistilRoles that are excluded from processing by the TA2
+var ExcludedDistilRoles = map[string]bool{
+	VarDistilRoleAugmented:  true,
+	VarDistilRoleMetadata:   true,
+	VarDistilRoleSystemData: true,
+}
+
 // IsIndexRole returns true if the d3m role is an index role.
 func IsIndexRole(role string) bool {
 	return role == RoleIndex || role == RoleMultiIndex

--- a/primitive/compute/description/fully_specified.go
+++ b/primitive/compute/description/fully_specified.go
@@ -450,10 +450,10 @@ func CreateDataFilterPipeline(name string, description string, variables []*mode
 	steps = append(steps, filterData...)
 	offset += len(filterData)
 
-	// drop metadata columns since we do not want them in the final output
+	// drop excluded distil roles columns since we do not want them in the final output
 	colsToDrop := []int{}
 	for _, v := range variables {
-		if v.DistilRole == model.VarDistilRoleMetadata {
+		if model.ExcludedDistilRoles[v.DistilRole] {
 			colsToDrop = append(colsToDrop, v.Index)
 		}
 	}
@@ -548,7 +548,7 @@ func CreateTargetRankingPipeline(name string, description string, target *model.
 	// dataset that is passed into the pipeline
 	datasetFeatures := []*model.Variable{}
 	for _, v := range features {
-		if v.Grouping == nil && v.DistilRole != model.VarDistilRoleMetadata {
+		if v.Grouping == nil && !model.ExcludedDistilRoles[v.DistilRole] {
 			datasetFeatures = append(datasetFeatures, v)
 		}
 	}

--- a/primitive/compute/description/preprocessing.go
+++ b/primitive/compute/description/preprocessing.go
@@ -146,7 +146,7 @@ func generatePrependSteps(datasetDescription *UserDatasetDescription,
 	// filter out group variables
 	datasetFeatures := []*model.Variable{}
 	for _, v := range datasetDescription.AllFeatures {
-		if v.Grouping == nil && v.DistilRole != model.VarDistilRoleMetadata {
+		if v.Grouping == nil && !model.ExcludedDistilRoles[v.DistilRole] {
 			datasetFeatures = append(datasetFeatures, v)
 		}
 	}


### PR DESCRIPTION
Move the map of `ExcludedDistilRoles` to distil-compute to be used in both distil-compute and distil. Updated the couple of places where we need to filter out those distil roles.