### PR TITLE
Join Multiple Columns

### DIFF
--- a/primitive/compute/description/fully_specified.go
+++ b/primitive/compute/description/fully_specified.go
@@ -679,10 +679,6 @@ func CreateJoinPipeline(name string, description string, leftJoinCols []*model.V
 	steps = append(steps, stepsRetype...)
 	offset += len(stepsRetype)
 	offsetLeft := offset - 1
-	//steps = append(steps, NewDistilColumnParserStep(nil, nil, []string{model.TA2RealVectorType}))
-	//steps = append(steps, NewDatasetWrapperStep(map[string]DataRef{"inputs": &StepDataRef{offsetLeft, "produce"}}, []string{"produce"}, offset, ""))
-	//offsetLeft = offset + 1
-	//offset = offset + 2
 
 	steps = append(steps, NewDenormalizeStep(map[string]DataRef{"inputs": &PipelineDataRef{1}}, []string{"produce"}))
 	offset = offset + 1
@@ -693,10 +689,6 @@ func CreateJoinPipeline(name string, description string, leftJoinCols []*model.V
 	steps = append(steps, stepsRetype...)
 	offset += len(stepsRetype)
 	offsetRight := offset - 1
-	//	steps = append(steps, NewDistilColumnParserStep(nil, nil, []string{model.TA2RealVectorType}))
-	//	steps = append(steps, NewDatasetWrapperStep(map[string]DataRef{"inputs": &StepDataRef{offsetRight, "produce"}}, []string{"produce"}, offset, ""))
-	//	offsetRight = offset + 1
-	//	offset = offset + 2
 
 	// merge two intput streams via a single join call
 	leftColNames := make([]string, len(leftJoinCols))

--- a/primitive/compute/description/fully_specified.go
+++ b/primitive/compute/description/fully_specified.go
@@ -669,10 +669,7 @@ func CreateGoatReversePipeline(name string, description string, lonSource *model
 func CreateJoinPipeline(name string, description string, leftJoinCols []*model.Variable, rightJoinCols []*model.Variable, accuracy float32) (*FullySpecifiedPipeline, error) {
 	steps := make([]Step, 0)
 	steps = append(steps, NewDenormalizeStep(map[string]DataRef{"inputs": &PipelineDataRef{0}}, []string{"produce"}))
-	steps = append(steps, NewDenormalizeStep(map[string]DataRef{"inputs": &PipelineDataRef{1}}, []string{"produce"}))
-	offset := 2
-	offsetLeft := 0
-	offsetRight := 1
+	offset := 1
 
 	// update semantic types as needed and parse vector types
 	stepsRetype, err := createUpdateSemanticTypes("", leftJoinCols, nil, offset)
@@ -681,23 +678,21 @@ func CreateJoinPipeline(name string, description string, leftJoinCols []*model.V
 	}
 	steps = append(steps, stepsRetype...)
 	offset += len(stepsRetype)
-	if len(stepsRetype) > 0 {
-		offsetLeft = offset - 1
-	}
+	offsetLeft := offset - 1
 	//steps = append(steps, NewDistilColumnParserStep(nil, nil, []string{model.TA2RealVectorType}))
 	//steps = append(steps, NewDatasetWrapperStep(map[string]DataRef{"inputs": &StepDataRef{offsetLeft, "produce"}}, []string{"produce"}, offset, ""))
 	//offsetLeft = offset + 1
 	//offset = offset + 2
 
+	steps = append(steps, NewDenormalizeStep(map[string]DataRef{"inputs": &PipelineDataRef{1}}, []string{"produce"}))
+	offset = offset + 1
 	stepsRetype, err = createUpdateSemanticTypes("", rightJoinCols, nil, offset)
 	if err != nil {
 		return nil, err
 	}
 	steps = append(steps, stepsRetype...)
 	offset += len(stepsRetype)
-	if len(stepsRetype) > 0 {
-		offsetRight = offset - 1
-	}
+	offsetRight := offset - 1
 	//	steps = append(steps, NewDistilColumnParserStep(nil, nil, []string{model.TA2RealVectorType}))
 	//	steps = append(steps, NewDatasetWrapperStep(map[string]DataRef{"inputs": &StepDataRef{offsetRight, "produce"}}, []string{"produce"}, offset, ""))
 	//	offsetRight = offset + 1

--- a/primitive/compute/description/fully_specified.go
+++ b/primitive/compute/description/fully_specified.go
@@ -692,7 +692,7 @@ func CreateJoinPipeline(name string, description string, leftJoinCol *model.Vari
 	steps = append(steps, NewJoinStep(
 		map[string]DataRef{"left": &StepDataRef{offsetLeft, "produce"}, "right": &StepDataRef{offsetRight, "produce"}},
 		[]string{"produce"},
-		leftJoinCol.DisplayName, rightJoinCol.DisplayName, accuracy,
+		[]string{leftJoinCol.HeaderName}, []string{rightJoinCol.HeaderName}, accuracy,
 	))
 	steps = append(steps, NewDatasetToDataframeStep(map[string]DataRef{"inputs": &StepDataRef{offset, "produce"}}, []string{"produce"}))
 

--- a/primitive/compute/description/fully_specified.go
+++ b/primitive/compute/description/fully_specified.go
@@ -666,7 +666,7 @@ func CreateGoatReversePipeline(name string, description string, lonSource *model
 
 // CreateJoinPipeline creates a pipeline that joins two input datasets using a caller supplied column.
 // Accuracy is a normalized value that controls how exact the join has to be.
-func CreateJoinPipeline(name string, description string, leftJoinCol *model.Variable, rightJoinCol *model.Variable, accuracy float32) (*FullySpecifiedPipeline, error) {
+func CreateJoinPipeline(name string, description string, leftJoinCols []*model.Variable, rightJoinCols []*model.Variable, accuracy float32) (*FullySpecifiedPipeline, error) {
 	steps := make([]Step, 0)
 	steps = append(steps, NewDenormalizeStep(map[string]DataRef{"inputs": &PipelineDataRef{0}}, []string{"produce"}))
 	steps = append(steps, NewDenormalizeStep(map[string]DataRef{"inputs": &PipelineDataRef{1}}, []string{"produce"}))
@@ -674,25 +674,47 @@ func CreateJoinPipeline(name string, description string, leftJoinCol *model.Vari
 	offsetLeft := 0
 	offsetRight := 1
 
-	// update semantic types as needed
-	if leftJoinCol.Type != leftJoinCol.OriginalType {
-		stepsRetype := getSemanticTypeUpdates(leftJoinCol, 0, offset)
-		steps = append(steps, stepsRetype...)
-		offset += len(stepsRetype)
+	// update semantic types as needed and parse vector types
+	stepsRetype, err := createUpdateSemanticTypes("", leftJoinCols, nil, offset)
+	if err != nil {
+		return nil, err
+	}
+	steps = append(steps, stepsRetype...)
+	offset += len(stepsRetype)
+	if len(stepsRetype) > 0 {
 		offsetLeft = offset - 1
 	}
-	if rightJoinCol.Type != rightJoinCol.OriginalType {
-		stepsRetype := getSemanticTypeUpdates(rightJoinCol, 1, offset)
-		steps = append(steps, stepsRetype...)
-		offset += len(stepsRetype)
+	//steps = append(steps, NewDistilColumnParserStep(nil, nil, []string{model.TA2RealVectorType}))
+	//steps = append(steps, NewDatasetWrapperStep(map[string]DataRef{"inputs": &StepDataRef{offsetLeft, "produce"}}, []string{"produce"}, offset, ""))
+	//offsetLeft = offset + 1
+	//offset = offset + 2
+
+	stepsRetype, err = createUpdateSemanticTypes("", rightJoinCols, nil, offset)
+	if err != nil {
+		return nil, err
+	}
+	steps = append(steps, stepsRetype...)
+	offset += len(stepsRetype)
+	if len(stepsRetype) > 0 {
 		offsetRight = offset - 1
 	}
+	//	steps = append(steps, NewDistilColumnParserStep(nil, nil, []string{model.TA2RealVectorType}))
+	//	steps = append(steps, NewDatasetWrapperStep(map[string]DataRef{"inputs": &StepDataRef{offsetRight, "produce"}}, []string{"produce"}, offset, ""))
+	//	offsetRight = offset + 1
+	//	offset = offset + 2
 
 	// merge two intput streams via a single join call
+	leftColNames := make([]string, len(leftJoinCols))
+	for i := range leftJoinCols {
+		leftColNames[i] = leftJoinCols[i].HeaderName
+	}
+	rightColNames := make([]string, len(rightJoinCols))
+	for i := range rightJoinCols {
+		rightColNames[i] = rightJoinCols[i].HeaderName
+	}
 	steps = append(steps, NewJoinStep(
 		map[string]DataRef{"left": &StepDataRef{offsetLeft, "produce"}, "right": &StepDataRef{offsetRight, "produce"}},
-		[]string{"produce"},
-		[]string{leftJoinCol.HeaderName}, []string{rightJoinCol.HeaderName}, accuracy,
+		[]string{"produce"}, leftColNames, rightColNames, accuracy,
 	))
 	steps = append(steps, NewDatasetToDataframeStep(map[string]DataRef{"inputs": &StepDataRef{offset, "produce"}}, []string{"produce"}))
 

--- a/primitive/compute/description/preprocessing.go
+++ b/primitive/compute/description/preprocessing.go
@@ -530,26 +530,6 @@ func createFilterData(filters []*model.Filter, columnIndices map[string]int, off
 	return filterSteps, nil
 }
 
-func getSemanticTypeUpdates(v *model.Variable, inputIndex int, offset int) []Step {
-	addType := model.MapTA2Type(v.Type)
-	removeType := model.MapTA2Type(v.OriginalType)
-
-	add := &ColumnUpdate{
-		SemanticTypes: []string{addType},
-		Indices:       []int{v.Index},
-	}
-	remove := &ColumnUpdate{
-		SemanticTypes: []string{removeType},
-		Indices:       []int{v.Index},
-	}
-	return []Step{
-		NewAddSemanticTypeStep(nil, nil, add),
-		NewDatasetWrapperStep(map[string]DataRef{"inputs": &StepDataRef{inputIndex, "produce"}}, []string{"produce"}, offset, ""),
-		NewRemoveSemanticTypeStep(nil, nil, remove),
-		NewDatasetWrapperStep(map[string]DataRef{"inputs": &StepDataRef{offset + 1, "produce"}}, []string{"produce"}, offset+2, ""),
-	}
-}
-
 func mapColumns(allFeatures []*model.Variable, selectedSet map[string]bool) map[string]int {
 	colIndices := make(map[string]int)
 	index := 0

--- a/primitive/compute/description/preprocessing_test.go
+++ b/primitive/compute/description/preprocessing_test.go
@@ -529,7 +529,7 @@ func TestCreateGoatReversePipeline(t *testing.T) {
 
 func TestCreateJoinPipeline(t *testing.T) {
 	pipeline, err := CreateJoinPipeline("join_test", "test join pipeline",
-		&model.Variable{DisplayName: "Doubles"}, &model.Variable{DisplayName: "horsepower"}, 0.8)
+		[]*model.Variable{{HeaderName: "Doubles", Type: "real", OriginalType: "string"}}, []*model.Variable{{HeaderName: "horsepower", Type: "real", OriginalType: "string"}}, 0.8)
 	assert.NoError(t, err)
 
 	data, err := proto.Marshal(pipeline.Pipeline)

--- a/primitive/compute/description/primitive_steps.go
+++ b/primitive/compute/description/primitive_steps.go
@@ -721,7 +721,11 @@ func NewGoatReverseStep(inputs map[string]DataRef, outputMethods []string, lonCo
 
 // NewJoinStep creates a step that will attempt to join two datasets a key column
 // from each.  This is currently a placeholder for testing/debugging only.
-func NewJoinStep(inputs map[string]DataRef, outputMethods []string, leftCol string, rightCol string, accuracy float32) *StepData {
+func NewJoinStep(inputs map[string]DataRef, outputMethods []string, leftCol []string, rightCol []string, accuracy float32) *StepData {
+	accuracyRepeated := make([]float32, len(leftCol))
+	for i := range leftCol {
+		accuracyRepeated[i] = accuracy
+	}
 	return NewStepData(
 		&pipeline.Primitive{
 			Id:         "6c3188bf-322d-4f9b-bb91-68151bf1f17f",
@@ -731,7 +735,7 @@ func NewJoinStep(inputs map[string]DataRef, outputMethods []string, leftCol stri
 			Digest:     "",
 		},
 		outputMethods,
-		map[string]interface{}{"left_col": leftCol, "right_col": rightCol, "accuracy": accuracy},
+		map[string]interface{}{"left_col": leftCol, "right_col": rightCol, "accuracy": accuracyRepeated},
 		inputs,
 	)
 }

--- a/primitive/compute/ta3ta2.go
+++ b/primitive/compute/ta3ta2.go
@@ -277,7 +277,7 @@ func ConvertMetricsFromTA3ToTA2(metrics []string, posLabel string) []*pipeline.P
 			ta2Metric = UndefinedMetric
 		}
 		res = append(res, &pipeline.ProblemPerformanceMetric{
-			Metric: ta2Metric,
+			Metric:   ta2Metric,
 			PosLabel: posLabel,
 		})
 	}


### PR DESCRIPTION
The update fuzzy join primitive supports joins using multiple features. These updates switch the join pipeline to accept lists of fields to join (along with a single accuracy value) to make use of the new ability.