### PR TITLE
use normalized name for header name

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -428,7 +428,8 @@ func NewVariable(index int, key, displayName, headerName, originalName, typ, ori
 		displayName = key
 	}
 	if headerName == "" {
-		headerName = key
+		// CSV is flexible with header names, but other formats like parquet are not
+		headerName = normalized
 	}
 	if originalType == "" {
 		originalType = typ


### PR DESCRIPTION
Part of fix for uncharted-distil/distil#2546.

Uses normalized key name as header name to ensure compatibility with parquet schema character restrictions.