### PR TITLE
Filter by set

### DIFF
--- a/model/filter.go
+++ b/model/filter.go
@@ -85,6 +85,18 @@ func NewBounds(minX float64, minY float64, width float64, height float64) *Bound
 	}
 }
 
+// FilterObject captures a collection of invertable filters.
+type FilterObject struct {
+	List   []*Filter `json:"list"`
+	Invert bool      `json:"invert"`
+}
+
+// FilterSet captures a set of filters representing one subset of data.
+type FilterSet struct {
+	FeatureFilters []FilterObject `json:"featureFilters"`
+	Mode           string         `json:"mode"`
+}
+
 // Filter defines a variable filter.
 type Filter struct {
 	Key              string   `json:"key"`
@@ -204,4 +216,35 @@ func NewRowFilter(mode string, d3mIndices []string) *Filter {
 		Mode:       mode,
 		D3mIndices: d3mIndices,
 	}
+}
+
+// IsValid verifies that a filter set is valid.
+func (fs *FilterSet) IsValid() bool {
+	// make sure every filter object is value
+	for _, fo := range fs.FeatureFilters {
+		if !fo.IsValid() {
+			return false
+		}
+	}
+
+	return true
+}
+
+// IsValid verifies that a filter object is valid.
+func (fo FilterObject) IsValid() bool {
+	// a filter object acts on a single filter, and they are all the same mode
+	mode := ""
+	key := ""
+	for _, f := range fo.List {
+		if key == "" {
+			key = f.Key
+			mode = f.Mode
+		} else if key != f.Key {
+			return false
+		} else if mode != f.Mode {
+			return false
+		}
+	}
+
+	return true
 }

--- a/model/filter.go
+++ b/model/filter.go
@@ -17,6 +17,8 @@ package model
 
 import (
 	"sort"
+
+	"github.com/uncharted-distil/distil-compute/model"
 )
 
 const (
@@ -247,4 +249,16 @@ func (fo FilterObject) IsValid() bool {
 	}
 
 	return true
+}
+
+// GetBaselineFilter returns only filters that form the baseline.
+func (fo FilterObject) GetBaselineFilter() []*model.Filter {
+	baseline := []*model.Filter{}
+	for _, filter := range fo.List {
+		if filter.IsBaselineFilter {
+			baseline = append(baseline, filter)
+		}
+	}
+
+	return baseline
 }

--- a/model/filter.go
+++ b/model/filter.go
@@ -17,8 +17,6 @@ package model
 
 import (
 	"sort"
-
-	"github.com/uncharted-distil/distil-compute/model"
 )
 
 const (
@@ -252,8 +250,8 @@ func (fo FilterObject) IsValid() bool {
 }
 
 // GetBaselineFilter returns only filters that form the baseline.
-func (fo FilterObject) GetBaselineFilter() []*model.Filter {
-	baseline := []*model.Filter{}
+func (fo FilterObject) GetBaselineFilter() []*Filter {
+	baseline := []*Filter{}
 	for _, filter := range fo.List {
 		if filter.IsBaselineFilter {
 			baseline = append(baseline, filter)

--- a/primitive/compute/description/fully_specified.go
+++ b/primitive/compute/description/fully_specified.go
@@ -422,7 +422,7 @@ func CreateGroupingFieldComposePipeline(name string, description string, colIndi
 }
 
 // CreateDataFilterPipeline creates a pipeline that will filter a dataset.
-func CreateDataFilterPipeline(name string, description string, variables []*model.Variable, filters []*model.Filter) (*FullySpecifiedPipeline, error) {
+func CreateDataFilterPipeline(name string, description string, variables []*model.Variable, filters []*model.FilterSet) (*FullySpecifiedPipeline, error) {
 	steps := []Step{}
 	offset := 0
 
@@ -443,7 +443,7 @@ func CreateDataFilterPipeline(name string, description string, variables []*mode
 	for _, v := range variables {
 		featureSet[strings.ToLower(v.Key)] = v.Index
 	}
-	filterData, err := createFilterData(filters, featureSet, offset)
+	filterData, err := filterBySet(filters, featureSet, offset)
 	if err != nil {
 		return nil, err
 	}

--- a/primitive/compute/description/preprocessing.go
+++ b/primitive/compute/description/preprocessing.go
@@ -30,7 +30,7 @@ type UserDatasetDescription struct {
 	AllFeatures      []*model.Variable
 	TargetFeature    *model.Variable
 	SelectedFeatures []string
-	Filters          []*model.Filter
+	Filters          []*model.FilterSet
 }
 
 // UserDatasetAugmentation contains the augmentation parameters required
@@ -85,7 +85,7 @@ func CreatePreFeaturizedDatasetPipeline(name string, description string, dataset
 	offset += len(updateSemanticTypes)
 
 	// apply filters
-	filterData, err := createFilterData(datasetDescription.Filters, featureSet, offset)
+	filterData, err := filterBySet(datasetDescription.Filters, featureSet, offset)
 	if err != nil {
 		return nil, err
 	}
@@ -252,7 +252,7 @@ func generatePrependSteps(datasetDescription *UserDatasetDescription,
 	offset += len(removeFeatures)
 
 	// add filter primitives
-	filterData, err := createFilterData(datasetDescription.Filters, columnIndices, offset)
+	filterData, err := filterBySet(datasetDescription.Filters, columnIndices, offset)
 	if err != nil {
 		return nil, err
 	}
@@ -447,7 +447,56 @@ func createUpdateSemanticTypes(target string, allFeatures []*model.Variable, sel
 	return semanticTypeUpdates, nil
 }
 
-func createFilterData(filters []*model.Filter, columnIndices map[string]int, offset int) ([]Step, error) {
+func filterBySet(filterSets []*model.FilterSet, columnIndices map[string]int, offset int) ([]Step, error) {
+	// only support exclusive filters
+	for _, fs := range filterSets {
+		if !fs.IsValid() {
+			return nil, errors.Errorf("invalid filter set detected")
+		}
+
+		for _, ff := range fs.FeatureFilters {
+			for _, f := range ff.List {
+				if f.Mode == model.IncludeFilter {
+					return nil, errors.Errorf("pipeline filtering only supports exclusive filters")
+				}
+			}
+		}
+	}
+
+	// Handle each filter set as an independent set of filters to exclude.
+	// A filter set is composed of filter objects joined together using logical ANDs.
+	// Each filter object contains filters acting on a single feature joined using logical ORs.
+	// Since the filtes are exclusion filters, the logical joining operator is reversed.
+	// Filters can be ORed together by having each filter operate on the same input
+	// then combining the output (removing duplicates). Filters can be ANDed together
+	// by having the output of one filter be the input of the following filter.
+	steps := []Step{}
+
+	// all filter sets act on the same input
+	for _, fs := range filterSets {
+		offsetFS := offset
+		filterOutputs := &ListStepDataRef{[]DataRef{}}
+		for _, ff := range fs.FeatureFilters {
+			// add necessary filters for each filter
+			stepsFeature, err := createFilterData(ff.List, columnIndices, offsetFS, offset)
+			if err != nil {
+				return nil, err
+			}
+			steps = append(steps, stepsFeature...)
+			offset = offset + len(stepsFeature)
+			filterOutputs.AddDataRef(&StepDataRef{offset, "produce"})
+		}
+
+		// combine the outputs, removing duplicates
+		steps = append(steps, NewVerticalConcatenationPrimitiveStep(nil, nil, true))
+		steps = append(steps, NewDatasetWrapperStep(map[string]DataRef{"inputs": filterOutputs}, []string{"produce"}, offset, ""))
+		offset += 2
+	}
+
+	return nil, nil
+}
+
+func createFilterData(filters []*model.Filter, columnIndices map[string]int, offsetInput int, offsetStep int) ([]Step, error) {
 
 	// Map the fiters to pipeline primitives
 	filterSteps := []Step{}
@@ -463,15 +512,15 @@ func createFilterData(filters []*model.Filter, columnIndices map[string]int, off
 		switch f.Type {
 		case model.NumericalFilter:
 			filter = NewNumericRangeFilterStep(nil, nil, colIndex, inclusive, *f.Min, *f.Max, false)
-			wrapper := NewDatasetWrapperStep(map[string]DataRef{"inputs": &StepDataRef{offset - 1, "produce"}}, []string{"produce"}, offset, "")
+			wrapper := NewDatasetWrapperStep(map[string]DataRef{"inputs": &StepDataRef{offsetInput - 1, "produce"}}, []string{"produce"}, offsetInput, "")
 			filterSteps = append(filterSteps, filter, wrapper)
-			offset += 2
+			offsetStep += 2
 
 		case model.CategoricalFilter:
 			filter = NewTermFilterStep(nil, nil, colIndex, inclusive, f.Categories, true)
-			wrapper := NewDatasetWrapperStep(map[string]DataRef{"inputs": &StepDataRef{offset - 1, "produce"}}, []string{"produce"}, offset, "")
+			wrapper := NewDatasetWrapperStep(map[string]DataRef{"inputs": &StepDataRef{offsetInput - 1, "produce"}}, []string{"produce"}, offsetInput, "")
 			filterSteps = append(filterSteps, filter, wrapper)
-			offset += 2
+			offsetStep += 2
 
 		case model.BivariateFilter:
 			split := strings.Split(filterKey, ":")
@@ -481,32 +530,32 @@ func createFilterData(filters []*model.Filter, columnIndices map[string]int, off
 			yColIndex := columnIndices[yCol]
 
 			filter = NewNumericRangeFilterStep(nil, nil, xColIndex, inclusive, f.Bounds.MinX, f.Bounds.MaxX, false)
-			wrapper := NewDatasetWrapperStep(map[string]DataRef{"inputs": &StepDataRef{offset - 1, "produce"}}, []string{"produce"}, offset, "")
+			wrapper := NewDatasetWrapperStep(map[string]DataRef{"inputs": &StepDataRef{offsetInput - 1, "produce"}}, []string{"produce"}, offsetInput, "")
 			filterSteps = append(filterSteps, filter, wrapper)
 
 			filter = NewNumericRangeFilterStep(nil, nil, yColIndex, inclusive, f.Bounds.MinY, f.Bounds.MaxY, false)
-			wrapper = NewDatasetWrapperStep(map[string]DataRef{"inputs": &StepDataRef{offset - 1, "produce"}}, []string{"produce"}, offset, "")
+			wrapper = NewDatasetWrapperStep(map[string]DataRef{"inputs": &StepDataRef{offsetInput - 1, "produce"}}, []string{"produce"}, offsetInput, "")
 			filterSteps = append(filterSteps, filter, wrapper)
 
-			offset += 4
+			offsetStep += 4
 
 		case model.RowFilter:
 			filter = NewTermFilterStep(nil, nil, colIndex, inclusive, f.D3mIndices, true)
-			wrapper := NewDatasetWrapperStep(map[string]DataRef{"inputs": &StepDataRef{offset - 1, "produce"}}, []string{"produce"}, offset, "")
+			wrapper := NewDatasetWrapperStep(map[string]DataRef{"inputs": &StepDataRef{offsetInput - 1, "produce"}}, []string{"produce"}, offsetInput, "")
 			filterSteps = append(filterSteps, filter, wrapper)
-			offset += 2
+			offsetStep += 2
 
 		case model.TextFilter:
 			filter = NewTermFilterStep(nil, nil, colIndex, inclusive, f.Categories, false)
-			wrapper := NewDatasetWrapperStep(map[string]DataRef{"inputs": &StepDataRef{offset - 1, "produce"}}, []string{"produce"}, offset, "")
+			wrapper := NewDatasetWrapperStep(map[string]DataRef{"inputs": &StepDataRef{offsetInput - 1, "produce"}}, []string{"produce"}, offsetInput, "")
 			filterSteps = append(filterSteps, filter, wrapper)
-			offset += 2
+			offsetStep += 2
 
 		case model.DatetimeFilter:
 			filter = NewDateTimeRangeFilterStep(nil, nil, colIndex, inclusive, *f.Min, *f.Max, false)
-			wrapper := NewDatasetWrapperStep(map[string]DataRef{"inputs": &StepDataRef{offset - 1, "produce"}}, []string{"produce"}, offset, "")
+			wrapper := NewDatasetWrapperStep(map[string]DataRef{"inputs": &StepDataRef{offsetInput - 1, "produce"}}, []string{"produce"}, offsetInput, "")
 			filterSteps = append(filterSteps, filter, wrapper)
-			offset += 2
+			offsetStep += 2
 
 		case model.GeoBoundsFilter:
 			// This is a filter that assumes to be working on a vector that contains 4 points defining a geographic area.  The vector
@@ -520,12 +569,12 @@ func createFilterData(filters []*model.Filter, columnIndices map[string]int, off
 			minValues := []float64{minX, minY, minX, minY, minX, minY, minX, minY}
 			maxValues := []float64{maxX, maxY, maxX, maxY, maxX, maxY, maxX, maxY}
 			filter = NewVectorBoundsFilterStep(nil, nil, colIndex, inclusive, minValues, maxValues, false)
-			wrapper := NewDatasetWrapperStep(map[string]DataRef{"inputs": &StepDataRef{offset - 1, "produce"}}, []string{"produce"}, offset, "")
+			wrapper := NewDatasetWrapperStep(map[string]DataRef{"inputs": &StepDataRef{offsetInput - 1, "produce"}}, []string{"produce"}, offsetInput, "")
 			filterSteps = append(filterSteps, filter, wrapper)
 
-			offset += 2
+			offsetStep += 2
 		}
-
+		offsetInput = offsetStep
 	}
 	return filterSteps, nil
 }

--- a/primitive/compute/description/preprocessing.go
+++ b/primitive/compute/description/preprocessing.go
@@ -493,7 +493,7 @@ func filterBySet(filterSets []*model.FilterSet, columnIndices map[string]int, of
 		offset += 2
 	}
 
-	return nil, nil
+	return steps, nil
 }
 
 func createFilterData(filters []*model.Filter, columnIndices map[string]int, offsetInput int, offsetStep int) ([]Step, error) {

--- a/primitive/compute/description/primitive_steps.go
+++ b/primitive/compute/description/primitive_steps.go
@@ -843,3 +843,20 @@ func NewPrefeaturisedPoolingStep(inputs map[string]DataRef, outputMethods []stri
 		inputs,
 	)
 }
+
+// NewVerticalConcatenationPrimitiveStep takes inputs and combines them into a single output.
+func NewVerticalConcatenationPrimitiveStep(inputs map[string]DataRef, outputMethods []string, removeDuplicate bool) *StepData {
+	args := map[string]interface{}{"remove_duplicate_rows": removeDuplicate}
+	return NewStepData(
+		&pipeline.Primitive{
+			Id:         "b93e3e85-c462-4290-8131-abc51d76a6dd",
+			Version:    "0.5.1",
+			Name:       "DistilVerticalConcat",
+			PythonPath: "d3m.primitives.data_transformation.concat.DistilVerticalConcat",
+			Digest:     "",
+		},
+		outputMethods,
+		args,
+		inputs,
+	)
+}

--- a/primitive/compute/description/step_data.go
+++ b/primitive/compute/description/step_data.go
@@ -186,14 +186,7 @@ func (s *StepData) BuildDescriptionStep() (*pipeline.PipelineDescriptionStep, er
 	// generate arguments entries
 	arguments := map[string]*pipeline.PrimitiveStepArgument{}
 	for argName, argDataRef := range s.Arguments {
-		arguments[argName] = &pipeline.PrimitiveStepArgument{
-			// only handle container args rights now - extend to others if required
-			Argument: &pipeline.PrimitiveStepArgument_Container{
-				Container: &pipeline.ContainerArgument{
-					Data: argDataRef.RefString(),
-				},
-			},
-		}
+		arguments[argName] = argDataRef.CreateDataRef()
 	}
 
 	// Generate hyper parameter entries - accepted go-natives types are currently intXX, string, bool, as well as list, map[string]


### PR DESCRIPTION
Added support for filtering in pipelines via filter sets. Each filter set represent a set of data to be excluded from the input. The assumptions on how to compose filters follow the same assumptions as distil, whereby filters acting on the same feature are ORed together, and filters between features are ANDed together. Since these are exclusion filters, in essence the operations are reversed (!(X AND Y) = !X OR !Y). To be able to specify the same input for multiple filters, the input offset and the primitive step offset had to be split.

To OR filters, the each filter is fed the same input and their outputs are then combined together (dropping duplicates). To be able to pass in a list of inputs, some changes had to be made to the existing data reference construction. The `ListStepDataRef` captures the needed information to be able to do just that.

The filter set and object structures were moved from distil to this repo since they are now required in the prepend construction.

In doing these updates, a few minor issues were fixed. It looks like timeseries fields were not using the proper lookup key (missing the lowercase). The column mapping function appears to also have used the feature slice index rather than the feature index.