### PR TITLE
Join Pair Accuracy

### DIFF
--- a/primitive/compute/description/preprocessing_test.go
+++ b/primitive/compute/description/preprocessing_test.go
@@ -528,9 +528,13 @@ func TestCreateGoatReversePipeline(t *testing.T) {
 }
 
 func TestCreateJoinPipeline(t *testing.T) {
-	pipeline, err := CreateJoinPipeline("join_test", "test join pipeline",
-		[]*model.Variable{{HeaderName: "Doubles", Type: "real", OriginalType: "string"}}, []*model.Variable{{HeaderName: "horsepower", Type: "real", OriginalType: "string"}},
-		[]*model.Variable{}, []*model.Variable{}, 0.8)
+	joins := []*Join{{
+		Left:     &model.Variable{HeaderName: "Doubles", Type: "real", OriginalType: "string"},
+		Right:    &model.Variable{HeaderName: "horsepower", Type: "real", OriginalType: "string"},
+		Accuracy: 0.8,
+	},
+	}
+	pipeline, err := CreateJoinPipeline("join_test", "test join pipeline", joins, nil, nil, "left")
 	assert.NoError(t, err)
 
 	data, err := proto.Marshal(pipeline.Pipeline)

--- a/primitive/compute/description/primitive_steps.go
+++ b/primitive/compute/description/primitive_steps.go
@@ -721,11 +721,7 @@ func NewGoatReverseStep(inputs map[string]DataRef, outputMethods []string, lonCo
 
 // NewJoinStep creates a step that will attempt to join two datasets a key column
 // from each.  This is currently a placeholder for testing/debugging only.
-func NewJoinStep(inputs map[string]DataRef, outputMethods []string, leftCol []string, rightCol []string, accuracy float32) *StepData {
-	accuracyRepeated := make([]float32, len(leftCol))
-	for i := range leftCol {
-		accuracyRepeated[i] = accuracy
-	}
+func NewJoinStep(inputs map[string]DataRef, outputMethods []string, leftCol []string, rightCol []string, accuracies []float64, joinType string) *StepData {
 	return NewStepData(
 		&pipeline.Primitive{
 			Id:         "6c3188bf-322d-4f9b-bb91-68151bf1f17f",
@@ -735,7 +731,7 @@ func NewJoinStep(inputs map[string]DataRef, outputMethods []string, leftCol []st
 			Digest:     "",
 		},
 		outputMethods,
-		map[string]interface{}{"left_col": leftCol, "right_col": rightCol, "accuracy": accuracyRepeated, "join_type": "left"},
+		map[string]interface{}{"left_col": leftCol, "right_col": rightCol, "accuracy": accuracies, "join_type": joinType},
 		inputs,
 	)
 }


### PR DESCRIPTION
Join accuracy is now captured as part of a specific join relationship between a field from the left dataset and the right dataset. This let's the user specify different join accuracies for every part of a join in a multi join.