### PR TITLE
Variable validity check

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -577,7 +577,7 @@ func (v *Variable) Clone() *Variable {
 
 // IsTA2Field indicates whether or not a particular variable is recognized by a TA2.
 func IsTA2Field(distilRole string, selectedRole string) bool {
-	if distilRole == VarDistilRoleData || distilRole == VarDistilRoleIndex {
+	if distilRole == VarDistilRoleData || distilRole == VarDistilRoleIndex || distilRole == VarDistilRoleSystemData {
 		return true
 	}
 
@@ -586,13 +586,6 @@ func IsTA2Field(distilRole string, selectedRole string) bool {
 	}
 
 	return false
-}
-
-// ExcludedDistilRoles are Distil roles that are excluded from processing by the TA2.
-var ExcludedDistilRoles = map[string]bool{
-	VarDistilRoleAugmented:  true,
-	VarDistilRoleMetadata:   true,
-	VarDistilRoleSystemData: true,
 }
 
 // IsIndexRole returns true if the d3m role is an index role.

--- a/primitive/compute/description/fully_specified.go
+++ b/primitive/compute/description/fully_specified.go
@@ -475,7 +475,7 @@ func CreateDataFilterPipeline(name string, description string, variables []*mode
 	// drop excluded distil roles columns since we do not want them in the final output
 	colsToDrop := []int{}
 	for _, v := range variables {
-		if model.ExcludedDistilRoles[v.DistilRole] {
+		if !model.IsTA2Field(v.DistilRole, v.SelectedRole) {
 			colsToDrop = append(colsToDrop, v.Index)
 		}
 	}
@@ -568,12 +568,7 @@ func CreateTargetRankingPipeline(name string, description string, target *model.
 
 	// ignore group and metadata variables - they are system-only variables that aren't part of the
 	// dataset that is passed into the pipeline
-	datasetFeatures := []*model.Variable{}
-	for _, v := range features {
-		if v.Grouping == nil && !model.ExcludedDistilRoles[v.DistilRole] {
-			datasetFeatures = append(datasetFeatures, v)
-		}
-	}
+	datasetFeatures := getTA2Features(features)
 
 	// recompute indices based on selected data subset
 	columnIndices := mapColumns(datasetFeatures, selectedFeatures)

--- a/primitive/compute/description/preprocessing_test.go
+++ b/primitive/compute/description/preprocessing_test.go
@@ -227,24 +227,28 @@ func TestCreateUserDatasetPipeline(t *testing.T) {
 			OriginalType: "ordinal",
 			Type:         "categorical",
 			Index:        0,
+			DistilRole:   model.VarDistilRoleData,
 		},
 		{
 			Key:          "test_var_1",
 			OriginalType: "categorical",
 			Type:         "integer",
 			Index:        1,
+			DistilRole:   model.VarDistilRoleData,
 		},
 		{
 			Key:          "test_var_2",
 			OriginalType: "categorical",
 			Type:         "integer",
 			Index:        2,
+			DistilRole:   model.VarDistilRoleData,
 		},
 		{
 			Key:          "test_var_3",
 			OriginalType: "categorical",
 			Type:         "integer",
 			Index:        3,
+			DistilRole:   model.VarDistilRoleData,
 		},
 	}
 


### PR DESCRIPTION
There were checks in a few places to filter a variable list down to those that are valid to be processed by the TA2.  This concept got blurred with the idea of variables that should be excluded from analytic processing (ranking, outlier detection).  In one case, we have something like a grouping variable, that shouldn't be passed down to the TA2 because it is a TA3 construct, vs. a variable that is generated by the pre-featurization stage, which is perfectly valid (and rquired) for TA2 processing, but should be excluded from analysis tasks.  The `IsTA2Field` check has been updated to properly handle all necessary roles, and replaces calls to analysis processing set in a few places.
