### PR TITLE
Tag bounding polygon

### DIFF
--- a/model/schema_types.go
+++ b/model/schema_types.go
@@ -160,6 +160,8 @@ const (
 	TA2TimeSeriesType = "https://metadata.datadrivendiscovery.org/types/Timeseries"
 	// TA2RealVectorType is the TA2 semantic type for vector data
 	TA2RealVectorType = "https://metadata.datadrivendiscovery.org/types/FloatVector"
+	// TA2BoundingPolygon is the TA2 semantic type for a bounding polygon
+	TA2BoundingPolygon = "https://metadata.datadrivendiscovery.org/types/BoundingPolygon"
 
 	// TA2 Role keys
 

--- a/primitive/compute/description/fully_specified.go
+++ b/primitive/compute/description/fully_specified.go
@@ -757,14 +757,16 @@ func CreateJoinPipeline(name string, description string, join *JoinDescription) 
 	steps = append(steps, NewDatasetWrapperStep(map[string]DataRef{"inputs": &StepDataRef{offset - 1, "produce"}}, []string{"produce"}, offset, ""))
 	offset += 2
 
-	excludeLeftIndices := make([]int, len(join.LeftExcludes))
-	for i, v := range join.LeftExcludes {
-		excludeLeftIndices[i] = v.Index
+	if len(join.LeftExcludes) > 0 {
+		excludeLeftIndices := make([]int, len(join.LeftExcludes))
+		for i, v := range join.LeftExcludes {
+			excludeLeftIndices[i] = v.Index
+		}
+		steps = append(steps, NewRemoveColumnsStep(nil, nil, excludeLeftIndices))
+		steps = append(steps, NewDatasetWrapperStep(map[string]DataRef{"inputs": &StepDataRef{offset - 1, "produce"}}, []string{"produce"}, offset, ""))
+		offset += 2
 	}
-	steps = append(steps, NewRemoveColumnsStep(nil, nil, excludeLeftIndices))
-	steps = append(steps, NewDatasetWrapperStep(map[string]DataRef{"inputs": &StepDataRef{offset - 1, "produce"}}, []string{"produce"}, offset, ""))
-	offsetLeft := offset + 1
-	offset += 2
+	offsetLeft := offset - 1
 
 	steps = append(steps, NewDenormalizeStep(map[string]DataRef{"inputs": &PipelineDataRef{1}}, []string{"produce"}))
 	offset = offset + 1
@@ -791,14 +793,17 @@ func CreateJoinPipeline(name string, description string, join *JoinDescription) 
 	steps = append(steps, NewDatasetWrapperStep(map[string]DataRef{"inputs": &StepDataRef{offset - 1, "produce"}}, []string{"produce"}, offset, ""))
 	offset = offset + 2
 
-	excludeRightIndices := make([]int, len(join.RightExcludes))
-	for i, v := range join.RightExcludes {
-		excludeRightIndices[i] = v.Index
+	if len(join.RightExcludes) > 0 {
+		excludeRightIndices := make([]int, len(join.RightExcludes))
+		for i, v := range join.RightExcludes {
+			excludeRightIndices[i] = v.Index
+		}
+		steps = append(steps, NewRemoveColumnsStep(nil, nil, excludeRightIndices))
+		steps = append(steps, NewDatasetWrapperStep(map[string]DataRef{"inputs": &StepDataRef{offset - 1, "produce"}}, []string{"produce"}, offset, ""))
+
+		offset += 2
 	}
-	steps = append(steps, NewRemoveColumnsStep(nil, nil, excludeRightIndices))
-	steps = append(steps, NewDatasetWrapperStep(map[string]DataRef{"inputs": &StepDataRef{offset - 1, "produce"}}, []string{"produce"}, offset, ""))
-	offsetRight := offset + 1
-	offset += 2
+	offsetRight := offset - 1
 
 	// merge two intput streams via a single join call
 	leftColNames := make([]string, len(leftJoinCols))

--- a/primitive/compute/description/fully_specified.go
+++ b/primitive/compute/description/fully_specified.go
@@ -54,6 +54,17 @@ type Join struct {
 	Absolute bool
 }
 
+// JoinDescription represents the complete information necessary to join
+// two datasets via a join pipeline.
+type JoinDescription struct {
+	Type           string
+	Joins          []*Join
+	RightExcludes  []*model.Variable
+	RightVariables []*model.Variable
+	LeftExcludes   []*model.Variable
+	LeftVariables  []*model.Variable
+}
+
 // MarshalSteps marshals a pipeline description into a json representation.
 func MarshalSteps(step *pipeline.PipelineDescription) (string, error) {
 	stepJSON, err := json.Marshal(step)
@@ -689,28 +700,36 @@ func CreateGoatReversePipeline(name string, description string, lonSource *model
 
 // CreateJoinPipeline creates a pipeline that joins two input datasets using a caller supplied column.
 // Accuracy is a normalized value that controls how exact the join has to be.
-func CreateJoinPipeline(name string, description string, joins []*Join,
-	leftExcludes []*model.Variable, rightExcludes []*model.Variable, joinType string) (*FullySpecifiedPipeline, error) {
+func CreateJoinPipeline(name string, description string, join *JoinDescription) (*FullySpecifiedPipeline, error) {
 	steps := make([]Step, 0)
 	steps = append(steps, NewDenormalizeStep(map[string]DataRef{"inputs": &PipelineDataRef{0}}, []string{"produce"}))
 	offset := 1
 
-	leftJoinCols := make([]*model.Variable, len(joins))
-	rightJoinCols := make([]*model.Variable, len(joins))
-	accuracies := make([]float64, len(joins))
-	absoluteAccuracies := make([]bool, len(joins))
+	leftVars := mapVariables(join.LeftVariables)
+	rightVars := mapVariables(join.RightVariables)
+
+	leftJoinCols := make([]*model.Variable, len(join.Joins))
+	rightJoinCols := make([]*model.Variable, len(join.Joins))
+	accuracies := make([]float64, len(join.Joins))
+	absoluteAccuracies := make([]bool, len(join.Joins))
 	leftJoinGeoBounds := []int{}
 	rightJoinGeoBounds := []int{}
-	for i, j := range joins {
+	for i, j := range join.Joins {
 		leftJoinCols[i] = j.Left
 		rightJoinCols[i] = j.Right
 		accuracies[i] = j.Accuracy
 		absoluteAccuracies[i] = j.Absolute
-		if model.IsGeoBounds(j.Left.Type) {
-			leftJoinGeoBounds = append(leftJoinGeoBounds, i)
+
+		// geobounds groups join on the underlying coordinate column
+		if j.Left.IsGrouping() && model.IsGeoBounds(j.Left.Type) {
+			group := j.Left.Grouping.(*model.GeoBoundsGrouping)
+			leftJoinGeoBounds = append(leftJoinGeoBounds, leftVars[group.CoordinatesCol].Index)
+			leftJoinCols[i] = leftVars[group.CoordinatesCol]
 		}
-		if model.IsGeoBounds(j.Right.Type) {
-			rightJoinGeoBounds = append(rightJoinGeoBounds, i)
+		if j.Right.IsGrouping() && model.IsGeoBounds(j.Right.Type) {
+			group := j.Right.Grouping.(*model.GeoBoundsGrouping)
+			rightJoinGeoBounds = append(rightJoinGeoBounds, rightVars[group.CoordinatesCol].Index)
+			rightJoinCols[i] = rightVars[group.CoordinatesCol]
 		}
 	}
 
@@ -725,7 +744,7 @@ func CreateJoinPipeline(name string, description string, joins []*Join,
 	// geobounds fields should be tagged with bounding polygon to trigger the appropriate join type
 	if len(leftJoinGeoBounds) > 0 {
 		leftGeoUpdate := &ColumnUpdate{
-			SemanticTypes: []string{model.TA2BoundingPolygon},
+			SemanticTypes: []string{model.TA2BoundingPolygon, model.TA2RealVectorType},
 			Indices:       leftJoinGeoBounds,
 		}
 		leftUpdate := NewAddSemanticTypeStep(nil, nil, leftGeoUpdate)
@@ -738,8 +757,8 @@ func CreateJoinPipeline(name string, description string, joins []*Join,
 	steps = append(steps, NewDatasetWrapperStep(map[string]DataRef{"inputs": &StepDataRef{offset - 1, "produce"}}, []string{"produce"}, offset, ""))
 	offset += 2
 
-	excludeLeftIndices := make([]int, len(leftExcludes))
-	for i, v := range leftExcludes {
+	excludeLeftIndices := make([]int, len(join.LeftExcludes))
+	for i, v := range join.LeftExcludes {
 		excludeLeftIndices[i] = v.Index
 	}
 	steps = append(steps, NewRemoveColumnsStep(nil, nil, excludeLeftIndices))
@@ -759,7 +778,7 @@ func CreateJoinPipeline(name string, description string, joins []*Join,
 	// geobounds fields should be tagged with bounding polygon to trigger the appropriate join type
 	if len(rightJoinGeoBounds) > 0 {
 		rightGeoUpdates := &ColumnUpdate{
-			SemanticTypes: []string{model.TA2BoundingPolygon},
+			SemanticTypes: []string{model.TA2BoundingPolygon, model.TA2RealVectorType},
 			Indices:       rightJoinGeoBounds,
 		}
 		rightUpdate := NewAddSemanticTypeStep(nil, nil, rightGeoUpdates)
@@ -772,8 +791,8 @@ func CreateJoinPipeline(name string, description string, joins []*Join,
 	steps = append(steps, NewDatasetWrapperStep(map[string]DataRef{"inputs": &StepDataRef{offset - 1, "produce"}}, []string{"produce"}, offset, ""))
 	offset = offset + 2
 
-	excludeRightIndices := make([]int, len(rightExcludes))
-	for i, v := range rightExcludes {
+	excludeRightIndices := make([]int, len(join.RightExcludes))
+	for i, v := range join.RightExcludes {
 		excludeRightIndices[i] = v.Index
 	}
 	steps = append(steps, NewRemoveColumnsStep(nil, nil, excludeRightIndices))
@@ -792,7 +811,7 @@ func CreateJoinPipeline(name string, description string, joins []*Join,
 	}
 	steps = append(steps, NewJoinStep(
 		map[string]DataRef{"left": &StepDataRef{offsetLeft, "produce"}, "right": &StepDataRef{offsetRight, "produce"}},
-		[]string{"produce"}, leftColNames, rightColNames, accuracies, absoluteAccuracies, joinType,
+		[]string{"produce"}, leftColNames, rightColNames, accuracies, absoluteAccuracies, join.Type,
 	))
 	steps = append(steps, NewDatasetToDataframeStep(map[string]DataRef{"inputs": &StepDataRef{offset, "produce"}}, []string{"produce"}))
 
@@ -1144,4 +1163,13 @@ func CreateDatamartAugmentPipeline(name string, description string, searchResult
 		EquivalentValues: []interface{}{pipelineJSON},
 	}
 	return fullySpecified, nil
+}
+
+func mapVariables(variables []*model.Variable) map[string]*model.Variable {
+	mapped := map[string]*model.Variable{}
+	for _, v := range variables {
+		mapped[v.Key] = v
+	}
+
+	return mapped
 }

--- a/primitive/compute/description/preprocessing_test.go
+++ b/primitive/compute/description/preprocessing_test.go
@@ -552,7 +552,11 @@ func TestCreateJoinPipeline(t *testing.T) {
 		Accuracy: 0.8,
 	},
 	}
-	pipeline, err := CreateJoinPipeline("join_test", "test join pipeline", joins, nil, nil, "left")
+	joinInfo := &JoinDescription{
+		Joins: joins,
+		Type:  "left",
+	}
+	pipeline, err := CreateJoinPipeline("join_test", "test join pipeline", joinInfo)
 	assert.NoError(t, err)
 
 	data, err := proto.Marshal(pipeline.Pipeline)


### PR DESCRIPTION
Updated join to handle geobounds being used in the join. They join on the underlying coordinates column, but need to be tagged as a bounding polygon to trigger the proper join approach.